### PR TITLE
Dataset metadata and access control

### DIFF
--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -8,6 +8,12 @@ The Registry maintains a list of the permissions and obligations for access to a
 
 Scheme-conforming data sources use [Scheme Catalog Requirements Documents](scheme_catalog_requirements.md) which specify the Access Rules for common formats of data sources.
 
+## Changes from Open Energy
+
+This access control specification is a simplification of Open Energy's access control. Open Energy was designed for one-to-many data products, which required the flexibility for each data provider to describe the individual access requirements for each of their products. Data sharing in a Trust Framework is many-to-many, where the access requirements are set by a sector-wide governance process.
+
+This specification will be iterated as use cases emerge. The current expectation, reflected in this specification, is that the governance process will describe the minimum set of roles permitted to access data under a specific licence, and the data provider may be allowed to expand this to additional roles.
+
 ## Example
 
 ```
@@ -29,11 +35,19 @@ The Registry maintains an RDF document at a well known URL which maps Licence UR
 
 The document is one or more `ib1:LicenceInterpretation` objects.
 
+The full legal text of the licence, linked from this RDF document, is the definitive description of what is allowed under this licence and the conditions for using the data. A user does not need to refer to this legal text to interpret the Grants and Obligations in this description, but they do need to rely on the legal governance process to accurately reflect the licence in the interpretation.
+
+The Grants listed in this interpretation are a list of things that can be done, but it may be incomplete, and does not include any things that cannot be done. Similarly, the list of Obligations may be incomplete. A licence interpretation which only contains the URL of the legal text with no Grants or Obligations is valid, and makes no claims about the contents of the legal text.
+
+For interoperability and consistency, Schemes should prefer to use Grants and Obligations that are defined in the underlying Trust Framework schema, then those defined by their own Trust Framework, and finally, create custom Grants and Obligations for their Scheme.
+
 ```
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix ib1: <http://registry.ib1.org/ns/1.0#>
 
 <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4>
 		a ib1:LicenceInterpretation ;
+	dcterms:license https://https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4/legal-text
 	ib1:grant ib1:use_any ;
 	ib1:grant ib1:adapt_any ;
 	ib1:grant ib1:combine_any ;
@@ -42,6 +56,8 @@ The document is one or more `ib1:LicenceInterpretation` objects.
 	ib1:obligation ib1:by;
 .
 ```
+[dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/license/)
+: The URL of the full legal text of the licence. This term is required.
 
 `ib1:grant`
 : The URL of a Grant, with the meaning defined in the contracts which govern the Trust Framework. A consumer may ignore any Grant that they do not understand and use the licence.

--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -6,7 +6,7 @@ A [catalog entry](metadata.md) specifies one or more groups and a licence. If a 
 
 The Registry maintains a list of the permissions and obligations for access to a data source under a given licence.
 
-Scheme-conforming data sources use a [Scheme Catalog Requirements Documents](scheme_catalog_requirements.md) which specifies the Access Rules for common formats of data sources.
+Scheme-conforming data sources use [Scheme Catalog Requirements Documents](scheme_catalog_requirements.md) which specify the Access Rules for common formats of data sources.
 
 ## Example
 
@@ -16,11 +16,11 @@ Scheme-conforming data sources use a [Scheme Catalog Requirements Documents](sch
 	# ...
     ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
     ib1:permitGroup <https://directory.ib1.org/group/archiver> ;
-    dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dcterms:license <http://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
 .
 ```
 
-These rules specify that members of either the "Report Provider" and "Archivers" groups may access the data with the CC BY 4.0 licence.
+These rules specify that members of either the "Report Provider" and "Archivers" groups may access the data with the Scheme's Voltage Reporting licence.
 
 
 ## Machine readable intepretation of Licences
@@ -60,7 +60,7 @@ Any additional grants designed **MUST** be within the namespace of the data prov
 **WARNING**: This section is provisional, the exact final set of base permissions has yet to be determined. Those shown below are a plausible first cut but should not be considered definitive.
 
 +--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| Category                 | Grant name                           | Meaning                                                                                |
+| Category                 | Grant name                                | Meaning                                                                                |
 +==========================+===========================================+========================================================================================+
 | **Use**                  |                                           | **Use the artefact internally**                                                        |
 +--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+

--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -16,7 +16,7 @@ Scheme-conforming data sources use [Scheme Catalog Requirements Documents](schem
 	# ...
     ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
     ib1:permitGroup <https://directory.ib1.org/group/archiver> ;
-    dcterms:license <http://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
+    dcterms:license <https://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
 .
 ```
 

--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -1,144 +1,66 @@
-# Access Control and Capability Grant Language
+# Access Control
 
-Access rules, capability grants, and obligations are explained in [Data Access Conditions](ops_guidelines/common_policies.md#data-access-conditions), this document specifies the
-precise syntax and values that can be used.
+Access to data sources is controlled by group membership and licences.
 
-An access rule contains:
+A [catalog entry](metadata.md) specifies one or more groups and a licence. If a participant is a member of any of the groups, they may access the data source under the specified licence.
 
+The Registry maintains a list of the permissions and obligations for access to a data source under a given licence.
 
-1. Zero or more conditions for access
-2. One or more capability grants to the data consumer if access is granted
-3. Zero or more obligations falling on the data consumer if access is granted
+Scheme-conforming data sources use a [Scheme Catalog Requirements Documents](scheme_catalog_requirements.md) which specifies the Access Rules for common formats of data sources.
 
-They are applied to properties of a [Data Consumer](glossary.md#term-Data-Consumer) while processing a request for data from a [Data Provider](glossary.md#term-Data-Provider). These properties can be modelled as a map of names to values; some values may be inferred by joining on the [ID](glossary.md#term-Identification) of the data consumer, some may be directly provided in the [Token introspection](ops_guidelines/technical_common.md#token-introspection) response.
+## Example
 
-## Syntax
-
-### Names
-
-**Names** consist of a namespace (`[a-z0-9_]+`), a `:` character, and a suffix (`[a-z0-9_.]+`). For example, `ib1:some_value`. Values asserted by Icebreaker One will always have a namespace `ib1`. The suffix may contain `.` characters, the namespace may not.
-
-### Rule syntax
-
-An access rule is represented as a single line string containing a comma separated list of zero or more Conditions, the literal string `grants`, and then a comma separated list of one or more Capabilities. Optionally, this may
-be followed by the literal `requires` and one or more Obligations in a comma separated list.
-
-```default
-[CONDITION]? ["," CONDITION]* "grants" CAPABILITY ["," CAPABILITY]* ["requires" OBLIGATION+ ["," OBLIGATION]
+```
+<https://data-provider-example.com/supply-voltage/v0>
+    a dcat:DataService ;
+	# ...
+    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
+    ib1:permitGroup <https://directory.ib1.org/group/archiver> ;
+    dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
+.
 ```
 
-**NOTE**: 
-* A rule with no conditions is valid, and is satisfied by all requests
-* All rules must grant at least one capability
-* Rules may have zero or more obligations
+These rules specify that members of either the "Report Provider" and "Archivers" groups may access the data with the CC BY 4.0 licence.
 
-See the following sections for specification of conditions and capabilities.
 
-## Conditions
+## Machine readable intepretation of Licences
 
-Conditions are unary or binary clauses.
+The Registry maintains an RDF document at a well known URL which maps Licence URLs to Grants (what you are allowed to do with the data) and Obligations (what you must do when providing derivative data to others).
 
-All conditions must be satisfied within a rule for that rule to be applied. There are no explicit boolean operators such as `or` or similar. For cases where alternative sets of rules could be applied the expectation is that data
-providers will specify multiple, potentially overlapping, rules to express this.
+The document is one or more `ib1:LicenceInterpretation` objects.
 
-### Unary clauses
+```
+@prefix ib1: <http://registry.ib1.org/ns/1.0/>
 
-Unary clauses consist of a single **named** condition. The clause is satisfied if that condition is `true`. This is typically used to denote a particular property such as *Icebreaker One Trust Framework membership* or similar where the existence of the property is sufficient to accept the data consumer.
-
-```json
- {"ib1:member" : true}
+<https://creativecommons.org/licenses/by/4.0/> a ib1:LicenceInterpretation ;
+	ib1:grant ib1:use_any ;
+	ib1:grant ib1:adapt_any ;
+	ib1:grant ib1:combine_any ;
+	ib1:grant ib1:redistribute_original ;
+	ib1:grant ib1:combine_external ;
+	ib1:obligation ib1:by;
+.
 ```
 
-### Binary clauses
+`ib1:grant`
+: The URL of a Grant, with the meaning defined in the contracts which govern the Trust Framework. A consumer may ignore any Grant that they do not understand and use the licence.
 
-Binary clauses consist of a **name** on the left hand side, an **operator**, and a **value** on the right hand side. The valid **operators** are shown in the table below. LHS, operator, and RHS are separated with at least one
-space character.
+`ib1:obligation`
+: The URL of an Obligation, with the meaning defined in the contracts which govern the Trust Framework. A consumer __MUST NOT__ use a licence if it includes an Obligation that they do not understand.
 
-**Values** can be numerals, dates, quoted strings, or homogeneous lists of these three types. Dates are specified as `dd/mm/yyyy`, we do not need a higher level of precision in any of our envisaged use cases, but if this is needed
-a datetime must be specified as a string compliant with [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339). To simplify expression in [JSON](glossary.md#term-Javascript-Object-Notation), quoted strings should be enclosed in single quote `'` characters. Lists are written as a comma separated list of strings surrounded by `[` and `]` characters. Lists are only valid RHS values for the
-`in` operator.
 
-### Operators
+## Grants
 
-+-----------------------------+-------------------------+--------------------------------------------------------------------------+
-| Operator                    | Range                   | Description                                                              |
-+=============================+=========================+==========================================================================+
-| `is`                        | Any                     | The condition passes if the value of the property on the LHS is exactly  |
-|                             |                         | equal to the value in the RHS                                            |
-+-----------------------------+-------------------------+--------------------------------------------------------------------------+
-| `before`                    | date or datetime        | The condition passes if the value of the property on the LHS is before   |
-|                             |                         | the date or datetime specifed as the RHS. Where a date needs to be       |
-|                             |                         | coerced to a datetime, it is done by setting it to 00:00.00 with the     |
-|                             |                         | same date                                                                |
-+-----------------------------+-------------------------+--------------------------------------------------------------------------+
-| `after`                     | date or datetime        | As above, but passes if the value of the property on the LHS is after    |
-|                             |                         | the date or datetime specified on the RHS.                               |
-+-----------------------------+-------------------------+--------------------------------------------------------------------------+
-| `max_age_days`              | date or datetime        | The condition passes if the value on the LHS corresponds to a date at    |
-|                             |                         | most X days in the past compared to the current date, where X is integer |
-|                             |                         | numeral specified as the RHS                                             |
-+-----------------------------+-------------------------+--------------------------------------------------------------------------+
-| `<`, `<=`, `>=`, `>`, `==`  | number                  | Conditions pass if the LHS is, respectively, less than, less than or     |
-|                             |                         | equal, greater than or equal, greater than, or strictly equal, to the    |
-|                             |                         | number on the RHS. Note that `==` and `is` are equivalent for numeric    |
-|                             |                         | quantities                                                               |
-+-----------------------------+-------------------------+--------------------------------------------------------------------------+
-| `in`                        | number or string        | Conditions pass if there is at least one item in the list specified in   |
-|                             |                         | the RHS which would match the `is` condition with respect to the LHS     |
-|                             |                         | value                                                                    |
-+-----------------------------+-------------------------+--------------------------------------------------------------------------+
+### Standard grants
 
-### Example conditions
+These are Grants where the URL prefix is in the IB1 Registry, usually abbreviated as  `ib1:`, indicating that they are defined as part of the Icebreaker One Trust Framework. Data providers **SHOULD NOT**, create their own Grants unless absolutely necessary as doing so acts against the aim of easy interoperability and comprehension of access and licensing rules.
 
-**NOTE**: The conditions shown below are examples, and should not be taken as indicative of standard properties of data
-consumers in the final system.
+Any additional grants designed **MUST** be within the namespace of the data provider responsible for their definition, and any such data provider **MUST** publish a clear, legally valid, definition of any such permissions. In addition, data providers creating custom permissions **MUST** inform the [TFGS](glossary.md#term-Trust-Framework-Governance-Service) of this, providing links to the aforementioned documentation.
 
-### Example condition clauses
-
-+------------------------------------------------+----------------------------------------------------------------------------------+
-| Condition                                      | Interpretation                                                                   |
-+================================================+==================================================================================+
-| `ib1:status is 'active'`                       | passes if the value of `ib1:status` is set, and is equal under string comparison |
-|                                                | to `active`                                                                      |
-+------------------------------------------------+----------------------------------------------------------------------------------+
-| `ib1:membership_expires after 24/10/2022`      | passes if the value of `ib1:membership_expires` is either a date or a datetime,  |
-|                                                | and is after the 24th October 2022                                               |
-+------------------------------------------------+----------------------------------------------------------------------------------+
-| `ib1:terms_signed max_age_days 20`             | passes if the value of `ib1:terms_signed` is either a date or a datetime, and    |
-|                                                | is at most 20 days from the current datetime. Note that dates with no time       |
-|                                                | component are equivalent to 00:00.00 on the specified date for comparison        |
-|                                                | purposes                                                                         |
-+------------------------------------------------+----------------------------------------------------------------------------------+
-| `some_group:membership_level >= 2`             | passes if the value of `some_group:membership_level` is a number and is greater  |
-|                                                | to or equal to two.                                                              |
-+------------------------------------------------+----------------------------------------------------------------------------------+
-| `ib1:org_type in ['council', 'academic']`      | passes if the value of `ib1:org_type` would be considered equal to either        |
-|                                                |  `'council'` or `'academic'` as if compared with `is`.                           |
-+------------------------------------------------+----------------------------------------------------------------------------------+
-| `ib1:member`                                   | passes if the value of `ib1:member` is `true`.                                   |
-+------------------------------------------------+----------------------------------------------------------------------------------+
-
-### Specifying multiple conditions
-
-Multiple conditions are separated with `,` characters. All conditions must be satisfied for the rule to pass, there are no sub-clauses or boolean operators. Any number of space characters are allowed before and after the `,` in a
-condition list.
-
-For example, `ib1:status is 'active', some_group:membership_level >=2` is the union of those two example conditions from the previous section and will only be satisfied if both conditions are individually satisfiable.
-
-## Capabilities
-
-Capability grants for a given set of access conditions are specified as a comma (`,`) separated list of **names**. There **MUST** be at least one **name** in this list, an empty capability grant list is not considered valid.
-
-### Standard capabilities
-
-These are capabilities where the namespace part of the **name** is `ib1`, indicating that they are defined as part of the Icebreaker One Trust Framework. Data providers **SHOULD NOT**, create their own capabilities unless absolutely necessary as doing so acts against the aim of easy interoperability and comprehension of access and licensing rules.
-
-Any additional capabilities designed **MUST** be prefixed with the organisation ID of the data provider responsible for their definition, and any such data provider **MUST** publish a clear, legally valid, definition of any such capabilities. In addition, data providers creating custom capabilities **MUST** inform the [TFGS](glossary.md#term-Trust-Framework-Governance-Service) of this, providing links to the aforementioned documentation.
-
-**WARNING**: This section is provisional, the exact final set of base capabilities has yet to be determined. Those shown below are a plausible first cut but should not be considered definitive.
+**WARNING**: This section is provisional, the exact final set of base permissions has yet to be determined. Those shown below are a plausible first cut but should not be considered definitive.
 
 +--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| Category                 | Capability name                           | Meaning                                                                                |
+| Category                 | Grant name                           | Meaning                                                                                |
 +==========================+===========================================+========================================================================================+
 | **Use**                  |                                           | **Use the artefact internally**                                                        |
 +--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
@@ -179,42 +101,9 @@ Any additional capabilities designed **MUST** be prefixed with the organisation 
 |                          |                                           | Consumer’s own products or services                                                    |
 +--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
 
-### Expressing Open Data licenses with capabilities
-
-The capabilities defined above in Standard capabilities are intended for [shared data](glossary.md#term-Shared-data), but data providers may also publish [open data](glossary.md#term-Open-data). An open data set by definition has no access conditions, so any access rules for such data sets **MUST** have an empty access condition list, and must use one of the following capabilities to declare that the data are licensed under a known OSI approved open license
-
-Rules **MUST NOT** grant a mix of capabilities in the `open` namespace and capabilities in other namespaces, as the semantics of this are not well defined.
-
-+-----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| Capability name                               | Corresponding open data license                                                                             |
-+===============================================+=============================================================================================================+
-| `open:cc_by_1.0`                              | [Creative Commons Attribution](https://creativecommons.org/licenses/by/4.0/) (v1.0, v2.0, v2.5, v3.0, v4.0  |
-| `open:cc_by_2.0`                              | respectively)                                                                                               |
-| `open:cc_by_2.5`                              |                                                                                                             |
-| `open:cc_by_3.0`                              |                                                                                                             |
-| `open:cc_by_4.0`                              |                                                                                                             |
-+-----------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| `open:cc_by_sa_1.0`                           | [Creative Commons Attribution ShareAlike](https://creativecommons.org/licenses/by-sa/4.0/) (v1.0, v2.0,     |
-| `open:cc_by_sa_2.0`                           | v2.5, v3.0, v4.0 respectively)                                                                              |
-| `open:cc_by_sa_2.5`                           |                                                                                                             |
-| `open:cc_by_sa_3.0`                           |                                                                                                             |
-| `open:cc_by_sa_4.0`                           |                                                                                                             |
-+-----------------------------------------------+-------------------------------------------------------------------------------------------------------------+ 
-| `open:cc0`                                    | [Public Domain Dedication](https://creativecommons.org/publicdomain/zero/1.0/) v1.0                         |
-+-----------------------------------------------+-------------------------------------------------------------------------------------------------------------+ 
-| `open:gfdl_1.1`                               | [GNU Free Documentation License](http://www.gnu.org/copyleft/fdl.html) (v1.1, 1.2, 1.3 respectively)        |
-| `open:gfdl_1.2`                               |                                                                                                             |
-| `open:gfdl_1.3`                               |                                                                                                             |
-+-----------------------------------------------+-------------------------------------------------------------------------------------------------------------+ 
-| `open:fal_1.2`                                | [Free Art License](http://artlibre.org/licence/lal/en/) (v1.2, v1.3 respectively)                           |
-| `open:fal_1.3`                                |                                                                                                             |
-+-----------------------------------------------+-------------------------------------------------------------------------------------------------------------+ 
-
-Open data sets **SHOULD** be released under the latest version of any given license.
-
 ## Obligations
 
-Obligations are constraints on what the data consumer can do with the data, restricting or specialising the capabilities granted. They are specified as a single **name**.
+Obligations are constraints on what the data consumer can do with the data, restricting or specialising the meaning of the Grants. They are specified as a URL, similar to Grants.
 
 ### Standard obligations
 
@@ -233,5 +122,9 @@ Obligations are constraints on what the data consumer can do with the data, rest
 
 **NOTE**: Two additional common constraints in existing (mostly open) licenses are NonCommercial and NoDerivatives. These are explicitly not included here as it is possible to express this through the access conditions (i.e. rather than declaring that a data set is only available for non-commercial usage it is better to say that only non-commercial entities may access it). This is not quite equivalent, but simpler and better defined than the relative minefield of defining ‘non commercial use’.
 <!--stackedit_data:
-eyJoaXN0b3J5IjpbMTE3NjE5MDkwMSwtMTk2OTEzODgyMl19
+eyJoaXN0b3J5IjpbLTEzMjMxMzY0NDIsNjExODUxNzY4LC04Mj
+k5NzM0MjcsMTkxMzMwNjE5MiwtMTE4ODE5OTQ5NSwtMjEzOTk0
+Nzg1MywyMDgwMjE4MzQsNzQwMTE3NDQ5LC0yMTMzOTc5NDYzLC
+03NDExMzYwOTAsOTM1MDgzNzQ3LC05NjkzMDEyNTAsMTE3NjE5
+MDkwMSwtMTk2OTEzODgyMl19
 -->

--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -11,12 +11,12 @@ Scheme-conforming data sources use [Scheme Catalog Requirements Documents](schem
 ## Example
 
 ```
-<https://data-provider-example.com/supply-voltage/v0>
+<https://data.example.com/supply-voltage/v0>
     a dcat:DataService ;
 	# ...
-    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
-    ib1:permitGroup <https://directory.ib1.org/group/archiver> ;
-    dcterms:license <https://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
+    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
+    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/archiver> ;
+    dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 .
 ```
 
@@ -30,9 +30,10 @@ The Registry maintains an RDF document at a well known URL which maps Licence UR
 The document is one or more `ib1:LicenceInterpretation` objects.
 
 ```
-@prefix ib1: <http://registry.ib1.org/ns/1.0/>
+@prefix ib1: <http://registry.ib1.org/ns/1.0#>
 
-<https://creativecommons.org/licenses/by/4.0/> a ib1:LicenceInterpretation ;
+<https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4>
+		a ib1:LicenceInterpretation ;
 	ib1:grant ib1:use_any ;
 	ib1:grant ib1:adapt_any ;
 	ib1:grant ib1:combine_any ;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,17 @@
+
+# Changelog
+
+## Version 0.2, 17 June 2024
+
+* [Catalog Metadata](metadata.md) is now a DCAT Dataset or Data Service, extended with IB1 terms.
+	* Standard terms now have restricted meanings when used with a Trust Framework.
+	* Format of data and API responses are specified in external files in the Registry for standardisation.
+	* Both Dataset and Data Service DCAT types are used.
+* [Access control](access_control_specification.md) updated to
+	* remove complex, reducing to a simple statement that one or more groups can access a dataset under a single licence.
+	* added machine readable interpretation of licences.
+	* renamed "Permissions" to "Grants" to clarify intent and avoid a name clash with another concept.
+* [Scheme Catalog Requirements](scheme_catalog_requirements.md) are added to define how data sources comply with standards across the Scheme.
+<!--stackedit_data:
+eyJoaXN0b3J5IjpbLTE4NjAwNzUwODBdfQ==
+-->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## Version 0.2, 17 June 2024
+## Version 0.2beta, 22 June 2024
 
 * [Catalog Metadata](metadata.md) is now a DCAT Dataset or Data Service, extended with IB1 terms.
 	* Standard terms now have restricted meanings when used with a Trust Framework.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,7 +1,7 @@
-# Data Set Metadata
+# Dataset & Data Service Metadata
 
-Each [Data Provider](glossary.md#term-Data-Provider) ([Data Provider](glossary.md#term-Data-Provider)) maintains a set of one or more metadata files, each of which can describe one or more 
-distinct data sets. These descriptions serve several purposes:
+Each [Data Provider](glossary.md#term-Data-Provider) maintains a set of one or more metadata files, each of which can describe one or more 
+distinct sources of data. These descriptions serve several purposes:
 
 
 1. They drive discovery descriptions are ingested into our search system and made available to a [Data Consumer](glossary.md#term-Data-Consumer) 
@@ -22,84 +22,125 @@ searching for particular kinds of data.
 
     4. Representation and internal semantics of expressions of the data
 
+## Dataset or Data Service?
+
+A Dataset:
+* is provided as one or more downloadable files,
+* may be published as part of series of Datasets covering the same source of data over different time periods, and
+* maintains historical access to previous periods.
+
+A Data Service:
+* is an API to query some data which uses parameters to specify a subset of data, including time period,
+* is specified formally by a machine readable API description, and
+* may require consent from a data subject external to the Trust Framework.
+
+They are described by slightly different information in metadata files.
+
+## Scheme-conforming
+
+A Scheme-conforming Dataset or Data Service meets a common standard across a Scheme to provide the same format and meaning of data across all Data Providers. This standard includes the format of the data or API, and the role who can access it under which licenses.
+
+These requirements are published by the Scheme Registry as machine readable [Scheme Catalog Requirements Documents](scheme_catalog_requirements.md), and metadata files link to them to show their conformance.
+
+Most Datasets and Data Services are Scheme-conforming. A Data Provider may publish data which is not Scheme-conforming to:
+* use the Trust Framework access control to share ad-hoc data amongst Trust Framework participants, or
+* use the Catalog to include Open Data in a public index.
+
 ## Metadata File Structure
 
-**NOTE**: The examples below use [YAML](glossary.md#term-YAML-Ain-t-Markup-Language) format for compactness and increased readability. Data providers may present this 
-information either in [YAML](glossary.md#term-YAML-Ain-t-Markup-Language) or in [JSON](glossary.md#term-Javascript-Object-Notation) form.
+The metadata is a standard [DCAT](https://www.w3.org/TR/vocab-dcat-3/) RDF file representing one or more sources of data. 
 
-The overall structure of the metadata file is a list of objects, each of which has the following structure:
+**NOTE**: The examples below use the [Turtle](https://www.w3.org/TR/turtle/) format for compactness and increased readability. Data providers may present this information in Turtle, RDF/XML, JSON-LD or N3 formats.
 
-```yaml
-- content:
-    # Discovery information
-  access:
-    # Access control and licensing information
-  transport:
-    # |API| information
-  representation:
-    # Data format information
-```
+Datasets are represented as Dataset DCAT objects with one or more Distributions. If the data measures the same thing over periods of time, then these must be linked together with a Data Series object. The format of the data is described by JSON Schema, XSD 1.1 or CSVW schemas.
 
-## Content Block
+Data Services are represented as Data Service DCAT objects, with OpenAPI specifications of the API and the format of the data in the responses.
 
-The `content` key contains a block of [JSON-LD](glossary.md#term-JavaScript-Object-Notation-for-Linked-Data) compatible information describing the conceptual content of the dataset. 
-A simple example is shown below:
+The URL of the DCAT object inside the RDF representation is the stable identifer of the Dataset or Data Service. This must remain constant each time the metadata file is fetched and over updates to the metadata.
 
-```yaml
-- content:
-    "@type": "dcat:Dataset"
-    "@context":
-       dcat: http://www.w3.org/ns/dcat#
-       dct: http://purl.org/dc/terms/
-       ib1: http://ib1.org/terms/
-    dct:title: My amazing data set
-    dct:description: This is a free text description of the data set
-    dcat:version: 0.1.2
-    dcat:versionNotes: This is a note on this particular version of the dataset
-    ib1:sensitivityClass: IB1-SA
-    ib1:dataSetStableIdentifier: myData
-```
+## Mandatory metadata fields
 
-These are the minimum properties every data set must define, they include terms from the 
-[Dublic Core](https://dublincore.org/) (`dct`) and [Data Catalog](https://www.w3.org/TR/vocab-dcat-2/) (`dcat`) 
-vocabularies, as well as from the Icebreaker One core ontology. Prefixes are defined in the [JSON-LD](glossary.md#term-JavaScript-Object-Notation-for-Linked-Data) `@context` object 
-as in the example above.
+The following fields must be included in every DCAT object. Metadata will be visible to all pariticipants in the Trust Framework, and may be visible to anyone on the open web without authentication in an open index.
 
-## Mandatory data content metadata fields
+[dcterms:title](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/title/)
+: Short title for this data set.
 
-+---------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| Key                                                                                                     | Value                                                                                                       |
-+=========================================================================================================+=============================================================================================================+
-| [dct:title](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/title/)              | Short title for this data set                                                                               |
-+---------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| [dct:description](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/description/)  | Longer form description of this data set. This is used in combination with the title and tags when people   |
-|                                                                                                         | search for data sets, so aim to include probable search words in the description.                           |
-+---------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| [dcat:version](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version)                           | Version number of the data set, this should preferably follow [semantic versioning](https://semver.org/) if |
-|                                                                                                         | possible. Versioning of the data set should be used to indicate changes in delivery mechanism, or in        |
-|                                                                                                         | representation, rather than for changes in the underlying data. For example, this should not be used to     |
-|                                                                                                         | differentiate between data sets from different years, rather it should be used to indicate whether a        |
-|                                                                                                         | potential data consumer might need to alter how it processes any returned data.                             |
-+---------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| [dcat:versionNotes](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version_notes)                | Notes used to explain any changes to this version                                                           |
-+---------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| `ib1:sensitivityClass`                                                                                  | The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this data set. In the current IB1  |
-|                                                                                                         | Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),         |
-|                                                                                                         | [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A), or                                              |
-|                                                                                                         | [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of    |
-|                                                                                                         | this property also determines the level of [API](glossary.md#term-Application-programming-interface)        |
-|                                                                                                         | security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) data sets being open data with |
-|                                                                                                         | no additional security, and the two shared data classes mandating                                           |
-|                                                                                                         | [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.                        |
-+---------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
-| `ib1:dataSetStableIdentifier`                                                                           | An identifier, unique to this [Data Provider](glossary.md#term-Data-Provider), which will not be changed,   |
-|                                                                                                         | and which will be used along with the data provider’s own ID to create a unique identifier for this data    |
-|                                                                                                         | set within [the Open Net Zero](https://opennetzero.org)                                                     |
-+---------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+[dcterms:publisher](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/publisher/)
+: The URL of the Data Provider's record in the Scheme Directory.
 
-### Additional metadata
+[dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#license)
+: The URL of a Licence, which must be registered with the Registry. All use of this data source is subject to this Licence.
 
-The information above is the minimum needed to ensure that a data set is visible in [the Open Net Zero](https://opennetzero.org)Energy search system. There 
+`ib1:sensitivityClass`
+: The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this data set. In the current IB1 Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),  [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A) or [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) data sets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
+
+Additional fields will be made mandatory for Scheme-confirming data sources by the Scheme Catalog Requirements Document.
+
+## Conformance and access control metadata fields
+
+`dcterms:conformsTo`
+: The URL of a Scheme Catalog Requirements Document in the Scheme Registry. Most metadata files will include this field.
+
+`ib1:permitGroup`
+: The URL of a group in the Directory to specify which groups may access this data source subject to the Licence in the `dcterms:license` term. One or more groups may be specified. See [Access Control Specification](access_control_specification.md).
+
+## Data Service metadata fields
+
+Data Services are represented by `dcat:DataService` objects with the common mandatory fields and Data Service specific fields.
+
+`dcat:endpointDescription`
+: The URL of an OpenAPI file, which fully documents the request parameters and responses. Responses must use XML or JSON. To allow the OpenAPI file to be used by multiple Data Providers, the file may only contain a single Server object, where the `url` is `"{endpointURL}"`, and `variables` sets the default to `"https://endpointurl-not-specified.ib1.org"`.
+
+`dcat:endpointURL`
+: The URL of this specific instance of the API. It is interpolated into the `url` specified in the OpenAPI file using the `endpointURL` variable.
+
+`ib1:heartbeatDescription`
+: The URL of an OpenAPI file (with Server specified as `dcat:endpointDescription`), which contains a single Path with a 200 response defined. This term will typically be the URL of one of a small number of standard OpenAPI files published in the Registry.
+
+Any additional metadata defined by published Standards may be added.
+
+## Dataset metadata fields
+
+Datasets are represented by `dcat:Dataset` objects with the common mandatory fields and Dataset specific fields.
+
+As Datasets will be discovered by browsing an index, they need additional descriptive metadata for discovery. The following fields are mandatory:
+
+[dcterms:description](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/description/)
+: Longer form description of this data set. This is used in combination with the title and tags when people search for data sets, so aim to include probable search words in the description.
+
+[dcat:version](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version)
+: Version number of the data set, this should preferably follow [semantic versioning](https://semver.org/) if possible. Versioning of the data set should be used to indicate changes in delivery mechanism, or in representation, rather than for changes in the underlying data. For example, this should not be used to differentiate between data sets from different years, rather it should be used to indicate whether a potential data consumer might need to alter how it processes any returned data. 
+
+[dcat:versionNotes](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version_notes)
+: Notes used to explain any changes to this version.
+
+[dcat:distribution](https://www.w3.org/TR/vocab-dcat-3/#Property:dataset_distribution)
+: URL of a `dcat:Distribution` for a downloadable file, see below for mandatory fields. Multiple Distribtions may be defined for the same data in different formats, but Scheme-conforming datasets will require a specific format.
+
+[dcat:inSeries](https://www.w3.org/TR/vocab-dcat-3/#Property:dataset_in_series)
+: Where the URL is part of a series of periodic datasets, the URL of a `dcat:DataSeries` which associates this Dataset with the overall series. The DataSeries is created by the publisher and contains their data only.
+
+Any additional metadata defined by published Standards may be added.
+
+### Distribution metadata fields
+
+To specify how the data may be downloaded, one or more associated `dcat:Distribution` objects must be included which contain:
+
+[dcat:downloadURL](https://www.w3.org/TR/vocab-dcat-3/#Property:distribution_download_url)
+: A stable URL for download of the dataset, subject to access controls specified in the Dataset object. Liveness of the server will be tested by making a HEAD request to this URL.
+
+[dcat:media_type](https://www.w3.org/TR/vocab-dcat-3/#Property:distribution_media_type)
+: The MIME type of the download file.
+
+`ib1:dataSchema`
+: The URL of a schema file specifying the format of the downloadable file. The type of schema depends on the `dcat:mediaType`:
+`application/json` are documented by JSON Schema files,
+`application/xml` by XSD 1.1 files, and
+`text/csv` by [CSVW](https://www.w3.org/ns/csvw) files.
+
+### Additional metadata for Datasets and Data Services
+
+The information above is the minimum needed to ensure that a data source can be used by the Trust Framework participants, and is visible in [the Open Net Zero](https://opennetzero.org) search system. There 
 are, however, other properties of a data set which may be useful to potential data consumers. Where such information can 
 be provided, it should be provided in as standard a form as possible - in practice this translates to making use of 
 existing ontologies such as DCAT and Dublin Core by preference, then shared, industry-specific, ontologies, and only 
@@ -110,290 +151,77 @@ Of particular note, and something we would like to ultimately expose in the Open
 
 We encourage use of the `dcat:keyword` list for data sets. These translate to “tags” in our web interface and are useful to group data sets around specific topics.
 
-```yaml
-dcat:keyword:
-  - solar
-  - electricity
-  - retrofit
-```
-
-## Access Block
-
-This section describes the kinds of licensing, expressed as sets of capabilities, and what, if any, conditions must be 
-satisfied before a [data consumer](glossary.md#term-Data-Consumer) can acquire these data.
-
-Each item within this section contains:
-
-
-1. A statement describing a set of conditions which must be satisfied to grant access, and the set of capabilities 
-granted should access be provided by this set of conditions. The exact specification for these statements can be
-found at [Access Control and Capability Grant Language](access_control_specification.md#access-control-and-capability-grant-language)
-
-
-2. A boolean property indicating whether the access conditions in [1] are sufficient (`true`), or simply indicative 
-(`false`). In the former case, a [data consumer](glossary.md#term-Data-Consumer) which satisfies all the conditions *will* be granted access, 
-in the latter they *may* be granted access, but there may be additional requirements not fully described here
-
-
-3. A pair of dates indicating the time range for which this access condition is valid. Data providers are encouraged to 
-commit to access and license conditions with a reasonable timeframe to allow potential consumers to plan their own
-activities
-
-```yaml
-access:
-  # Access constraint to licensing predicates
-  - rule: ib1oe:verified, ib1oe:last_update max_age_days 60 grants ib1oe:use_any
-    sufficient: true
-    appliesFrom: 20231-04-22
-    appliesTo: 20242-04-22
-  - rule: group:some_group grants ib1oe:use_any, ib1oe:adapt_any
-    sufficient: false
-    appliesFrom: 20231-04-22
-    appliesTo: 20242-04-22
-```
-
-## Transport Block
-
-This section describes the on the wire transport protocol, normally HTTP, but with scope to describe out-of-band 
-transports with an initial HTTP negotiation process. It contains at least a single `http` key, the value of which
-must be valid [Open|API|](https://swagger.io/specification/) 
-
-For example:
-
-```yaml
-transport:
-  http:
-    # This block is mandatory, and contains the Open|API| spec for the secured or open
-    # HTTP endpoints (depending on data class)
-    openapi: 3.0.0
-    info:
-      title: Sample |API|
-      description: CSV format data
-      version: 0.1.0
-    servers:
-      - url: http://data-provider-example.com
-        description: Describe this particular server if needed
-    paths:
-      "/data":
-        get:
-          summary: Returns a CSV containing all the data
-          description: If we had any more to describe, we'd do it here
-          responses:
-            '200':
-              description: CSV data stream
-```
-
-**NOTE**: Because [API](glossary.md#term-Application-programming-interface) security is defined in relation to the data sensitivity class of the data set, it is not necessary to 
-define the security of any presented [API](glossary.md#term-Application-programming-interface) in this section. Data sets in class [IB1OE-O](glossary.md#term-Data-sensitivity-class-open) must expose an [API](glossary.md#term-Application-programming-interface) with no extra
-security measures, and those in [IB1OE-SA](glossary.md#term-Data-sensitivity-class-shared-A) and [IB1OE-SB](glossary.md#term-Data-sensitivity-class-shared-B) must be secured by [FAPI](glossary.md#term-Financial-Grade-API) using the Ib1 Trust FrameworkOpen Energy trust services.
-
-### Heartbeat URL
-
-Data providers **SHOULD** create a secured endpoint to act as a heartbeat - if this is specifed then the [TFOEGS](glossary.md#term-Trust-FrameworkOpen-Energy-Governance-Service) will 
-periodically call it to assertain liveness and optionally gather metrics as described in
-[Heartbeat and monitoring endpoint](ops_guidelines/data_provider_ops_guidelines.md#heartbeat-and-monitoring-endpoint)
-
-A hearbeat URL can be specified as a single key `heartbeat_url` with the value being the fully qualified URL at which 
-the hearbeat response is exposed.
-
-## Representation Block
-
-This section describes the format of any data received by a [data consumer](glossary.md#term-Data-Consumer) from this data set. The IB1 Trust FrameworkOpen Energy does 
-not mandate particular formats, so this section is guidance rather than specification.
-
-The only required element in this section is a key `mime` which should contain the 
-[media type](https://en.wikipedia.org/wiki/Media_type) of the returned data. At a bare minimum this allows a client to 
-load data into some kind of tooling. Depending on this value, other objects may be present.
-
-### text/csv
-
-This type indicates that data is presented in CSV format. In this case, an optional key `csvw` may be defined, and 
-should contain valid [JSON-LD](glossary.md#term-JavaScript-Object-Notation-for-Linked-Data) following the [CSV for the Web](https://www.w3.org/TR/tabular-data-primer/) guidelines:
-
-```yaml
-representation:
-  mime: text/csv
-  csvw:
-    # This is only applicable if the mime type is text/csv
-    "@context": http://www.w3.org/ns/csvw
-    tableSchema:
-      columns:
-        - titles: country
-        - titles: country group
-        - titles: name (en)
-        - titles: name (fr)
-        - titles: name (de)
-        - titles: latitude
-        - titles: longitude
-```
-
-### Other types
-
-This is currently open for consultation, we would like to be able to guide data providers towards particular 
-representation types for particular kinds of information, and make use of any existing ontologies or standards such as
-the [Common Information Model](https://en.wikipedia.org/wiki/Common_Information_Model_(electricity)) where such 
-standards will aid interoperability between IB1 Trust FrameworkOpen Energy participants and the wider community.
 
 ## Full Example
 
-Putting together all the fragments from previous sections produces the following - this represents a single data set, 
-in the full metadata file this would be contained within a list. [YAML](glossary.md#term-YAML-Ain-t-Markup-Language) form:
+### Data Service
 
-```yaml
-- content:
-    "@type": "dcat:Dataset"
-    "@context":
-      dcat: http://www.w3.org/ns/dcat#
-      dct: http://purl.org/dc/terms/
-      ib1: http://ib1.org/terms/
-    dct:title: My amazing data set
-    dct:description: This is a free text description of the data set
-    dcat:version: 0.1.2
-    dcat:versionNotes: This is a note on this particular version of the dataset
-    ib1:sensitivityClass: IB1-SA
-    ib1:dataSetStableIdentifier: myData
-  access:
-    # Access constraint to licensing predicates
-    - rule: ib1:verified, ib1:last_update max_age_days 60 grants ib1:use_any
-      sufficient: true
-      appliesFrom: 20231-04-22
-      appliesTo: 20242-04-22
-    - rule: group:some_group grants ib1oe:use_any, ib1oe:adapt_any
-      sufficient: false
-      appliesFrom: 20231-04-22
-      appliesTo: 20242-04-22
-  transport:
-    http:
-      # This block is mandatory, and contains the Open|API| spec for the secured or open
-      # HTTP endpoints (depending on data class)
-      openapi: 3.0.0
-      info:
-        title: Sample |API|
-        description: CSV format data
-        version: 0.1.0
-      servers:
-        - url: http://data-provider-example.com
-          description: Describe this particular server if needed
-      paths:
-        "/data":
-          get:
-            summary: Returns a CSV containing all the data
-            description: If we had any more to describe, we'd do it here
-          responses:
-            '200':
-              description: CSV data stream
-  representation:
-    mime: text/csv
-    csvw:
-      # This is only applicable if the mime type is text/csv
-      "@context": http://www.w3.org/ns/csvw
-      tableSchema:
-        columns:
-          - titles: country
-          - titles: country group
-          - titles: name (en)
-          - titles: name (fr)
-          - titles: name (de)
-          - titles: latitude
-          - titles: longitude
+```
+@prefix dcat: <http://www.w3.org/ns/dcat#> . 
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ib1: <http://registry.ib1.org/ns/1.0/> .
+
+<https://data-provider-example.com/supply-voltage/v0>
+    a dcat:DataService ;
+    dcterms:title "Electricity Supply Voltage"@en ;
+    dcterms:description "API to query supply voltage across the grid"@en ;
+    dcterms:publisher <https://registry.ib1.org/member/my-energy-company> ;
+    dcterms:conformsTo <https://registry.ib1.org/class/supply-voltage> ; 
+    dcat:version "0.1.2" ;
+    dcat:endpointDescription <https://registry.ib1.org/api/electricty-voltage> ;
+    ib1:heartbeatDescription <https://registry.ib1.org/api/heartbeat-simple> ;
+    dcat:endpointURL <https://data-provider-example.com/supply-voltage/v0> ;
+    ib1:sensitivityClass "IB1-SA" ;
+    ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
+    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
+    dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
+.
 ```
 
-Or, in [JSON](glossary.md#term-Javascript-Object-Notation) form:
+### Dataset with Distributions and Data Series
 
-```json
-[
-  {
-    "content": {
-      "@type": "dcat:Dataset",
-      "@context": {
-        "dcat": "http://www.w3.org/ns/dcat#",
-        "dct": "http://purl.org/dc/terms/",
-        "ib1": "http://ib1.org/terms/"
-      },
-      "dct:title": "My amazing data set",
-      "dct:description": "This is a free text description of the data set",
-      "dcat:version": "0.1.2",
-      "dcat:versionNotes": "This is a note on this particular version of the dataset",
-      "ib1:sensitivityClass": "IB1-SA",
-      "ib1oe:dataSetStableIdentifier": "myData"
-    },
-    "access": [
-      {
-        "rule": "ib1:verified, ib1:last_update max_age_days 60 grants ib1:use_any",
-        "sufficient": true,
-        "appliesFrom": "20231-04-22T00:00:00.000Z",
-        "appliesTo": "20242-04-22T00:00:00.000Z"
-      },
-      {
-        "rule": "group:some_group grants ib1:use_any, ib1:adapt_any",
-        "sufficient": false,
-        "appliesFrom": "20231-04-22T00:00:00.000Z",
-        "appliesTo": "20242-04-22T00:00:00.000Z"
-      }
-    ],
-    "transport": {
-      "http": {
-        "openapi": "3.0.0",
-        "info": {
-          "title": "Sample |API|",
-          "description": "CSV format data",
-          "version": "0.1.0"
-        },
-        "servers": [
-          {
-            "url": "http://data-provider-example.com",
-            "description": "Describe this particular server if needed"
-          }
-        ],
-        "paths": {
-          "/data": {
-            "get": {
-              "summary": "Returns a CSV containing all the data",
-              "description": "If we had any more to describe, we'd do it here"
-            },
-            "responses": {
-              "200": {
-                "description": "CSV data stream"
-              }
-            }
-          }
-        }
-      }
-    },
-    "representation": {
-      "mime": "text/csv",
-      "csvw": {
-        "@context": "http://www.w3.org/ns/csvw",
-        "tableSchema": {
-          "columns": [
-            {
-              "titles": "country"
-            },
-            {
-              "titles": "country group"
-            },
-            {
-              "titles": "name (en)"
-            },
-            {
-              "titles": "name (fr)"
-            },
-            {
-              "titles": "name (de)"
-            },
-            {
-              "titles": "latitude"
-            },
-            {
-              "titles": "longitude"
-            }
-          ]
-        }
-      }
-    }
-  }
-]
+```
+@prefix dcat: <http://www.w3.org/ns/dcat#> . 
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix ib1: <http://registry.ib1.org/ns/1.0/> .
+
+<https://data-provider-example.com/generation-report/oct2024>
+    a dcat:Dataset ;
+    dcterms:title "Generation Report Oct 2024"@en ;
+    dcterms:description "Data report on generation"@en ;
+    dcterms:publisher <https://registry.ib1.org/member/my-energy-company> ;
+    dcterms:conformsTo <https://registry.ib1.org/class/generation-report> ; 
+    dcat:version "0.1.2" ;
+    dcat:inSeries <https://data-provider-example.com/generation-report>;
+    dcat:distribution <https://data-provider-example.com/generation-report/oct2024/csv> ;
+    dcat:keyword "solar"@en,
+	    "electricity"@en,
+	    "retrofit"@en ;
+    ib1:sensitivityClass "IB1-SA" ;
+    ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
+    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
+    dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
+.
+
+<https://data-provider-example.com/generation-report/oct2024/download>
+	a dcat:Distribution ;
+	dcterms:description "CSV"@en ;
+	dcat:downloadURL <https://data-provider-example.com/generation-report/oct2024/csv> ;
+	dcat:media_type "text/csv"@en ;
+	ib1:dataSchema <https://registry.ib1.org/format/generation-report/v2> ;
+.
+
+<https://data-provider-example.com/generation-report>
+    a dcat:DatasetSeries ;
+    dcterms:title "Generation Reports from My Energy Company"@en ;
+.
 ```
 <!--stackedit_data:
-eyJoaXN0b3J5IjpbMTIxNTE5NTIxNiwtMTc2ODQxMzMyNl19
+eyJoaXN0b3J5IjpbLTE4MzY0ODI1OTIsLTExODU4MjA4MjMsMz
+UyNDI5NSwtMTc3Mjk1NTY3OSwtMTUwMzY5NDAwLDU0MDU3NjUz
+LC0xMDMyMjMyNTIzLC04NDA2NTUxODksLTU3OTM2NTg2MCwtMT
+M2MzYzMTQwMSwtMTQ3MDQzMzM2MywxNzUxMjM0OTkwLC02MTE3
+OTM1MTAsMTUxNzk1OTM4OCwxMTg5MzQyMzY2LDM1MTI3Njc4MC
+w1OTQ5MjE2NjUsMTE0OTc3MTc0MCwtMjU0Mjk4NzQ4LDIxMjk2
+NzMzNzNdfQ==
 -->

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -175,24 +175,23 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
 ```
 @prefix dcat: <http://www.w3.org/ns/dcat#> . 
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix ib1: <http://registry.ib1.org/ns/1.0/> .
+@prefix ib1: <http://registry.ib1.org/ns/1.0#> .
 
-<https://data-provider-example.com/supply-voltage/v0>
+<https://example.com/supply-voltage/v0>
     a dcat:DataService ;
-    dcterms:title "Electricity Supply Voltage"@en ;
-    dcterms:description "API to query supply voltage across the grid"@en ;
-    dcterms:publisher <https://registry.ib1.org/member/my-energy-company> ;
-    dcterms:conformsTo <https://registry.ib1.org/class/supply-voltage> ; 
-    dcat:version "0.1.2" ;
-    dcat:endpointDescription <https://registry.ib1.org/api/electricity-voltage> ;
-    ib1:heartbeatDescription <https://registry.ib1.org/api/heartbeat-simple> ;
-    dcat:endpointURL <https://data-provider-example.com/supply-voltage/v0> ;
-    ib1:trustFramework <http://estf.registry.ib1.org> ;
+    dcterms:title "Electricity Generation Voltage"@en ;
+    dcterms:description "API to query generation supply voltage"@en ;
+    dcterms:publisher <https://directory.estf.ib1.org/member/827252> ;
+    dcterms:conformsTo <https://registry.estf.ib1.org/scheme/electricity/standard/supply-voltage> ; 
+    dcat:endpointDescription <https://registry.estf.ib1.org/scheme/electricity/api/voltage> ;
+    ib1:heartbeatDescription <https://registry.estf.ib1.org/api/heartbeat-simple/1.0> ;
+    dcat:endpointURL <https://grid03.api.example.com/generation-voltage/v0> ;
+    ib1:trustFramework <http://registry.estf.ib1.org/trust-framework> ;
     ib1:datasetAssurance "IcebreakerOne.DatasetLevel1" ;
     ib1:sensitivityClass "IB1-SA" ;
-    ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
-    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
-    dcterms:license <https://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
+    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/network-operator> ;
+    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
+    dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 .
 ```
 
@@ -201,37 +200,37 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
 ```
 @prefix dcat: <http://www.w3.org/ns/dcat#> . 
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix ib1: <http://registry.ib1.org/ns/1.0/> .
+@prefix ib1: <http://registry.ib1.org/ns/1.0#> .
 
-<https://data-provider-example.com/generation-report/oct2024>
+<https://data.example.com/generation-report/oct2024>
     a dcat:Dataset ;
     dcterms:title "Generation Report Oct 2024"@en ;
     dcterms:description "Data report on generation"@en ;
-    dcterms:publisher <https://registry.ib1.org/member/my-energy-company> ;
-    dcterms:conformsTo <https://registry.ib1.org/class/generation-report> ; 
+    dcterms:publisher <https://directory.estf.ib1.org/member/827252> ;
+    dcterms:conformsTo <https://registry.estf.ib1.org/scheme/electricity/standard/generation-report> ; 
     dcat:version "0.1.2" ;
-    dcat:inSeries <https://data-provider-example.com/generation-report>;
-    dcat:distribution <https://data-provider-example.com/generation-report/oct2024/csv> ;
+    dcat:inSeries <https://data.example.com/generation-report>;
+    dcat:distribution <https://data.example.com/generation-report/oct2024/csv> ;
     dcat:keyword "solar"@en,
 	    "electricity"@en,
 	    "retrofit"@en ;
-    ib1:trustFramework <http://estf.registry.ib1.org> ;
+    ib1:trustFramework <http://registry.estf.ib1.org/trust-framework> ;
     ib1:datasetAssurance "IcebreakerOne.DatasetLevel1" ;
     ib1:sensitivityClass "IB1-SA" ;
-    ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
-    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
-    dcterms:license <https://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
+    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/network-operator> ;
+    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
+    dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/generation-reporting/2.1> ;
 .
 
-<https://data-provider-example.com/generation-report/oct2024/download>
+<https://data.example.com/generation-report/oct2024/download>
 	a dcat:Distribution ;
 	dcterms:description "CSV"@en ;
-	dcat:downloadURL <https://data-provider-example.com/generation-report/oct2024/csv> ;
+	dcat:downloadURL <https://data.example.com/generation-report/oct2024/csv> ;
 	dcat:media_type "text/csv"@en ;
-	ib1:dataSchema <https://registry.ib1.org/format/generation-report/v2> ;
+	ib1:dataSchema <https://registry.estf.ib1.org/scheme/electricity/format/generation-report/2.0> ;
 .
 
-<https://data-provider-example.com/generation-report>
+<https://data.example.com/generation-report>
     a dcat:DatasetSeries ;
     dcterms:title "Generation Reports from My Energy Company"@en ;
 .

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -80,7 +80,10 @@ The following fields must be included in every DCAT object. Metadata will be vis
 `ib1:sensitivityClass`
 : The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this dataset. In the current IB1 Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),  [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A) or [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) datasets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
 
-Additional fields may be made mandatory for Scheme-confirming data sources by the Scheme Catalog Requirements Document.
+More information about publishing assured data within a Trust Framework is available on the [How to become an assured data publisher](https://icebreakerone.org/sops/assured-data-publishing/) section of the Icebreaker One website.
+
+Additional fields may be made mandatory for Scheme-conforming data sources by the Scheme Catalog Requirements Document.
+
 
 ## Conformance and access control metadata fields
 
@@ -162,7 +165,7 @@ using internal or custom representation when absolutely necessary.
 Of particular note, and something we would like to ultimately expose in the Open Net Zero search interface, is information about the geospatial and temporal ranges of entries within a dataset. This is a complex subject, but one that has already been handled by DCAT. If you need to express this kind of information, please do so according to the standards laid out 
 [here](https://www.w3.org/TR/vocab-dcat-2/#time-and-space).
 
-We encourage use of the `dcat:keyword` list for datasets. These translate to “tags” in our web interface and are useful to group datasets around specific topics.
+We encourage use of the `dcat:keyword` list for datasets. These translate to “tags” in Open Net Zero's web interface and are useful to group datasets around specific topics.
 
 
 ## Full Example

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -11,7 +11,7 @@ searching for particular kinds of data.
 2. They inform consumption of that data, providing information on:
 
 
-    1. The [API](glossary.md#term-Application-programming-interface) required to access the data set
+    1. The [API](glossary.md#term-Application-programming-interface) required to access the data source
 
 
     2. Any access constraints which may need to be satisfied
@@ -27,7 +27,7 @@ searching for particular kinds of data.
 A Dataset:
 * is provided as one or more downloadable files,
 * may be published as part of series of Datasets covering the same source of data over different time periods, and
-* maintains historical access to previous periods.
+* should maintain historical access to previous periods.
 
 A Data Service:
 * is an API to query some data which uses parameters to specify a subset of data, including time period,
@@ -38,12 +38,12 @@ They are described by slightly different information in metadata files.
 
 ## Scheme-conforming
 
-A Scheme-conforming Dataset or Data Service meets a common standard across a Scheme to provide the same format and meaning of data across all Data Providers. This standard includes the format of the data or API, and the role who can access it under which licenses.
+A Scheme-conforming Dataset or Data Service meets the data format and meaning requirements of the Scheme, along with any required access and licence conditions.
 
 These requirements are published by the Scheme Registry as machine readable [Scheme Catalog Requirements Documents](scheme_catalog_requirements.md), and metadata files link to them to show their conformance.
 
 Most Datasets and Data Services are Scheme-conforming. A Data Provider may publish data which is not Scheme-conforming to:
-* use the Trust Framework access control to share ad-hoc data amongst Trust Framework participants, or
+* use Scheme licences and roles to share ad-hoc Shared Data with Scheme participants (where the Scheme doesn't expressly disallow this), or
 * use the Catalog to include Open Data in a public index.
 
 ## Metadata File Structure
@@ -54,7 +54,7 @@ The metadata is a standard [DCAT](https://www.w3.org/TR/vocab-dcat-3/) RDF file 
 
 Datasets are represented as Dataset DCAT objects with one or more Distributions. If the data measures the same thing over periods of time, then these must be linked together with a Data Series object. The format of the data is described by JSON Schema, XSD 1.1 or CSVW schemas.
 
-Data Services are represented as Data Service DCAT objects, with OpenAPI specifications of the API and the format of the data in the responses.
+Data Services are represented as Data Service DCAT objects, with [OpenAPI](https://swagger.io/specification/) specifications of the API and the format of the data in the responses.
 
 The URL of the DCAT object inside the RDF representation is the stable identifer of the Dataset or Data Service. This must remain constant each time the metadata file is fetched and over updates to the metadata.
 
@@ -63,18 +63,24 @@ The URL of the DCAT object inside the RDF representation is the stable identifer
 The following fields must be included in every DCAT object. Metadata will be visible to all pariticipants in the Trust Framework, and may be visible to anyone on the open web without authentication in an open index.
 
 [dcterms:title](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/title/)
-: Short title for this data set.
+: Short title for this dataset.
 
 [dcterms:publisher](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/publisher/)
 : The URL of the Data Provider's record in the Scheme Directory.
 
 [dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#license)
-: The URL of a Licence, which must be registered with the Registry. All use of this data source is subject to this Licence.
+: The URL of a Licence. All use of this data source is subject to this Licence. Where a data source is Scheme-conforming, the URL will be registered in the Registry.
+
+`ib1:trustFramework`
+: The URL of the Trust Framework(s) the dataset is assured under.
+
+`ib1:datasetAssurance`
+: The assurance level for this dataset.
 
 `ib1:sensitivityClass`
-: The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this data set. In the current IB1 Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),  [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A) or [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) data sets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
+: The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this dataset. In the current IB1 Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),  [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A) or [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) datasets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
 
-Additional fields will be made mandatory for Scheme-confirming data sources by the Scheme Catalog Requirements Document.
+Additional fields may be made mandatory for Scheme-confirming data sources by the Scheme Catalog Requirements Document.
 
 ## Conformance and access control metadata fields
 
@@ -82,20 +88,20 @@ Additional fields will be made mandatory for Scheme-confirming data sources by t
 : The URL of a Scheme Catalog Requirements Document in the Scheme Registry. Most metadata files will include this field.
 
 `ib1:permitGroup`
-: The URL of a group in the Directory to specify which groups may access this data source subject to the Licence in the `dcterms:license` term. One or more groups may be specified. See [Access Control Specification](access_control_specification.md).
+: The URLs of one or more groups in the Directory which may access this data source subject to the Licence in the `dcterms:license` term, unless the data is open data with a `ib1:sensitivityClass` of `IB1-O`. See [Access Control Specification](access_control_specification.md).
 
 ## Data Service metadata fields
 
 Data Services are represented by `dcat:DataService` objects with the common mandatory fields and Data Service specific fields.
 
 `dcat:endpointDescription`
-: The URL of an OpenAPI file, which fully documents the request parameters and responses. Responses must use XML or JSON. To allow the OpenAPI file to be used by multiple Data Providers, the file may only contain a single Server object, where the `url` is `"{endpointURL}"`, and `variables` sets the default to `"https://endpointurl-not-specified.ib1.org"`.
+: The URL of an OpenAPI file, which fully documents the request parameters and responses. Responses must use XML or JSON. To allow the OpenAPI file to be used by multiple Data Providers, the file may only contain a single [Server object](https://swagger.io/specification/#server-object), where the `url` is `"{endpointURL}"`, and `variables` sets the default to `"https://endpointurl-not-specified.ib1.org"`.
 
 `dcat:endpointURL`
 : The URL of this specific instance of the API. It is interpolated into the `url` specified in the OpenAPI file using the `endpointURL` variable.
 
 `ib1:heartbeatDescription`
-: The URL of an OpenAPI file (with Server specified as `dcat:endpointDescription`), which contains a single Path with a 200 response defined. This term will typically be the URL of one of a small number of standard OpenAPI files published in the Registry.
+: An optional URL of an OpenAPI file (with Server specified as `dcat:endpointDescription`), which contains a single Path with a 200 response defined. This term will typically be the URL of one of a small number of standard OpenAPI files published in the Registry.
 
 Any additional metadata defined by published Standards may be added.
 
@@ -106,19 +112,24 @@ Datasets are represented by `dcat:Dataset` objects with the common mandatory fie
 As Datasets will be discovered by browsing an index, they need additional descriptive metadata for discovery. The following fields are mandatory:
 
 [dcterms:description](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/description/)
-: Longer form description of this data set. This is used in combination with the title and tags when people search for data sets, so aim to include probable search words in the description.
+: Longer form description of this dataset. This is used in combination with the title and tags when people search for datasets, so aim to include probable search words in the description.
+
+[dcat:distribution](https://www.w3.org/TR/vocab-dcat-3/#Property:dataset_distribution)
+: URL of a `dcat:Distribution` for a downloadable file, see below for mandatory fields. Multiple Distributions may be defined for the same data in different formats, taking into account any requirements and restrictions for Scheme-conforming datasets.
+
+The following fields are mandatory when the dataset is part of a series of periodic datasets:
+
+[dcat:inSeries](https://www.w3.org/TR/vocab-dcat-3/#Property:dataset_in_series)
+: The URL of a `dcat:DataSeries` which associates this Dataset with the overall series. The DataSeries is created by the publisher and contains their data only.
+
+The following fields are optional:
 
 [dcat:version](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version)
-: Version number of the data set, this should preferably follow [semantic versioning](https://semver.org/) if possible. Versioning of the data set should be used to indicate changes in delivery mechanism, or in representation, rather than for changes in the underlying data. For example, this should not be used to differentiate between data sets from different years, rather it should be used to indicate whether a potential data consumer might need to alter how it processes any returned data. 
+: Version number of the dataset, this should preferably follow [semantic versioning](https://semver.org/) if possible. Versioning of the dataset should be used to indicate changes in delivery mechanism, or in representation, rather than for changes in the underlying data. For example, this should not be used to differentiate between datasets from different years, rather it should be used to indicate whether a potential data consumer might need to alter how it processes any returned data. 
 
 [dcat:versionNotes](https://www.w3.org/TR/vocab-dcat-3/#Property:resource_version_notes)
 : Notes used to explain any changes to this version.
 
-[dcat:distribution](https://www.w3.org/TR/vocab-dcat-3/#Property:dataset_distribution)
-: URL of a `dcat:Distribution` for a downloadable file, see below for mandatory fields. Multiple Distribtions may be defined for the same data in different formats, but Scheme-conforming datasets will require a specific format.
-
-[dcat:inSeries](https://www.w3.org/TR/vocab-dcat-3/#Property:dataset_in_series)
-: Where the URL is part of a series of periodic datasets, the URL of a `dcat:DataSeries` which associates this Dataset with the overall series. The DataSeries is created by the publisher and contains their data only.
 
 Any additional metadata defined by published Standards may be added.
 
@@ -132,6 +143,8 @@ To specify how the data may be downloaded, one or more associated `dcat:Distribu
 [dcat:media_type](https://www.w3.org/TR/vocab-dcat-3/#Property:distribution_media_type)
 : The MIME type of the download file.
 
+The following fields are optional, but encouraged. They are mandatory for higher assurance and Scheme-conforming data sources.
+
 `ib1:dataSchema`
 : The URL of a schema file specifying the format of the downloadable file. The type of schema depends on the `dcat:mediaType`:
 `application/json` are documented by JSON Schema files,
@@ -140,16 +153,16 @@ To specify how the data may be downloaded, one or more associated `dcat:Distribu
 
 ### Additional metadata for Datasets and Data Services
 
-The information above is the minimum needed to ensure that a data source can be used by the Trust Framework participants, and is visible in [the Open Net Zero](https://opennetzero.org) search system. There 
-are, however, other properties of a data set which may be useful to potential data consumers. Where such information can 
+The fields marked as mandatory are the minimum needed to ensure that a data source can be used by the Trust Framework participants, and is visible in [the Open Net Zero](https://opennetzero.org) search system. There 
+are, however, other properties of a dataset which may be useful to potential data consumers. Where such information can 
 be provided, it should be provided in as standard a form as possible - in practice this translates to making use of 
 existing ontologies such as DCAT and Dublin Core by preference, then shared, industry-specific, ontologies, and only 
 using internal or custom representation when absolutely necessary.
 
-Of particular note, and something we would like to ultimately expose in the Open Net Zero search interface, is information about the geospatial and temporal ranges of entries within a data set. This is a complex subject, but one that has already been handled by DCAT. If you need to express this kind of information, please do so according to the standards laid out 
+Of particular note, and something we would like to ultimately expose in the Open Net Zero search interface, is information about the geospatial and temporal ranges of entries within a dataset. This is a complex subject, but one that has already been handled by DCAT. If you need to express this kind of information, please do so according to the standards laid out 
 [here](https://www.w3.org/TR/vocab-dcat-2/#time-and-space).
 
-We encourage use of the `dcat:keyword` list for data sets. These translate to “tags” in our web interface and are useful to group data sets around specific topics.
+We encourage use of the `dcat:keyword` list for datasets. These translate to “tags” in our web interface and are useful to group datasets around specific topics.
 
 
 ## Full Example
@@ -171,6 +184,8 @@ We encourage use of the `dcat:keyword` list for data sets. These translate to �
     dcat:endpointDescription <https://registry.ib1.org/api/electricty-voltage> ;
     ib1:heartbeatDescription <https://registry.ib1.org/api/heartbeat-simple> ;
     dcat:endpointURL <https://data-provider-example.com/supply-voltage/v0> ;
+    ib1:trustFramework <http://estf.registry.ib1.org> ;
+    ib1:datasetAssurance "IcebreakerOne.DatasetLevel1" ;
     ib1:sensitivityClass "IB1-SA" ;
     ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
     ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
@@ -197,6 +212,8 @@ We encourage use of the `dcat:keyword` list for data sets. These translate to �
     dcat:keyword "solar"@en,
 	    "electricity"@en,
 	    "retrofit"@en ;
+    ib1:trustFramework <http://estf.registry.ib1.org> ;
+    ib1:datasetAssurance "IcebreakerOne.DatasetLevel1" ;
     ib1:sensitivityClass "IB1-SA" ;
     ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
     ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -184,7 +184,7 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
     dcterms:publisher <https://registry.ib1.org/member/my-energy-company> ;
     dcterms:conformsTo <https://registry.ib1.org/class/supply-voltage> ; 
     dcat:version "0.1.2" ;
-    dcat:endpointDescription <https://registry.ib1.org/api/electricty-voltage> ;
+    dcat:endpointDescription <https://registry.ib1.org/api/electricity-voltage> ;
     ib1:heartbeatDescription <https://registry.ib1.org/api/heartbeat-simple> ;
     dcat:endpointURL <https://data-provider-example.com/supply-voltage/v0> ;
     ib1:trustFramework <http://estf.registry.ib1.org> ;
@@ -192,7 +192,7 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
     ib1:sensitivityClass "IB1-SA" ;
     ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
     ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
-    dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dcterms:license <https://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
 .
 ```
 
@@ -220,7 +220,7 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
     ib1:sensitivityClass "IB1-SA" ;
     ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
     ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
-    dcterms:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dcterms:license <https://estf.registry.ib1.org/schemes/supply/licence/voltage-reporting-v1> ;
 .
 
 <https://data-provider-example.com/generation-report/oct2024/download>

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -79,6 +79,7 @@ The following fields must be included in every DCAT object. Metadata will be vis
 
 `ib1:sensitivityClass`
 : The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this dataset. In the current IB1 Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),  [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A) or [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) datasets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
+*Under development:* [IB1-SP](glossary.md#term-Data-sensitivity-class-personal) may be used for APIs which expose personal data with the end user's consent. The `ib1:oauthIssuer` term must be present.
 
 More information about publishing assured data within a Trust Framework is available on the [How to become an assured data publisher](https://icebreakerone.org/sops/assured-data-publishing/) section of the Icebreaker One website.
 
@@ -102,6 +103,9 @@ Data Services are represented by `dcat:DataService` objects with the common mand
 
 `dcat:endpointURL`
 : The URL of this specific instance of the API. It is interpolated into the `url` specified in the OpenAPI file using the `endpointURL` variable.
+
+`ib1:oauthIssuer`
+: Where access to data requires end user consent or selection of an account at the provider, the URL of the [OAuth Issuer](https://datatracker.ietf.org/doc/html/rfc8414#section-2) which is used to authenticate before accessing this Data Service. This field is required for data with a `ib1:sensitivityClass` of `IP1-SP`, and may be used for other classes.
 
 `ib1:heartbeatDescription`
 : An optional URL of an OpenAPI file (with Server specified as `dcat:endpointDescription`), which contains a single Path with a 200 response defined. This term will typically be the URL of one of a small number of standard OpenAPI files published in the Registry.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -79,7 +79,7 @@ The following fields must be included in every DCAT object. Metadata will be vis
 
 `ib1:sensitivityClass`
 : The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this dataset. In the current IB1 Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),  [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A) or [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) datasets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
-*Under development:* [IB1-SP](glossary.md#term-Data-sensitivity-class-personal) may be used for APIs which expose personal data with the end user's consent. The `ib1:oauthIssuer` term must be present.
+*Under development:* [IB1-SP](glossary.md#term-Data-sensitivity-class-personal) may be used for Data Service APIs which expose personal data with the end user's consent, in which case the `ib1:oauthIssuer` term must be present.
 
 More information about publishing assured data within a Trust Framework is available on the [How to become an assured data publisher](https://icebreakerone.org/sops/assured-data-publishing/) section of the Icebreaker One website.
 

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -24,13 +24,16 @@ It is an RDF document published by the Registry.
 	    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
 	    dcterms:licence <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 	];
-	ib1:includeAllAllowAditional ib1:permitGroup ;
+	ib1:requireAllAndAllowAdditional ib1:permitGroup ;
+	ib1:requireAbsenceOf ib1:oauthIssuer ;
 .
 ```
 
 This example defines a standard Supply Voltage API that is provided by multiple providers in a Trust Framework. It specifies the API in detail with the `dcat:endpointDescription` referring to an OpenAPI specification hosted by the Registry. It uses a standard `ib1:heartbeatDescription` to check for liveness, using a standard heartbeat request defined in an OpenAPI specification hosted by the Registry.
 
-For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitGroup`. Because `ib1:includeAllAllowAditional` is used for the access rules, it allows the publisher to widen access to additional groups, as long as the groups in this document are included.
+For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitGroup`. Because `ib1:requireAllAndAllowAdditional` is used for the access rules, it allows the publisher to widen access to additional groups, as long as the groups in this document are included.
+
+Because the API does not require end user consent, `ib1:requireAbsenceOf` is used to prohibit the use of an OAuth Issuer.
 
 ## Object specification
 
@@ -49,11 +52,17 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 (no modifier)
 : All the values in the requirements must be included for a term which does not have a modifier. No additonal values for that term are allowed.
 
-`ib1:includeAllAllowAdditional <term>`
+`ib1:requireAllAndAllowAdditional <term>`
 : All the values in the requirements must be included for this term, but additional values are allowed.
 
-`ib1:includeOneOf <term>`
+`ib1:requireAnyOneOf <term>`
 : Exactly one of the values in the requirements must be included for this term. No other values are allowed.
+
+`ib1:requireAnyValue <term>`
+: The term must be present, with any valid value.
+
+`ib1:requireAbsenceOf <term>`
+: The term must not be present.
 
 
 <!--stackedit_data:

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -17,7 +17,7 @@ It is an RDF document published by the Registry.
 	dcterms:title "Supply Voltage API Requirements" ;
 	ib1:requiredType dcat:DataService ;
 	ib1:requiredMetadata [ a ib1:RequiredMetadata ;
-	    dcat:endpointDescription <https://registry.ib1.org/api/electricty-voltage> ;
+	    dcat:endpointDescription <https://registry.ib1.org/api/electricity-voltage> ;
 	    ib1:heartbeatDescription <https://registry.ib1.org/api/heartbeat-simple> ;
 	    ib1:sensitivityClass "IB1-SA" ;
 	    ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -8,7 +8,9 @@ It is an RDF document published by the Registry.
 ## Example
 
 ```
-@prefix ib1: <http://registry.ib1.org/ns/1.0/>
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> . 
+@prefix ib1: <http://registry.ib1.org/ns/1.0/> .
 
 <https://registry.ib1.org/class/supply-voltage>
 	a ib1:SchemeCatalogRequirements ;
@@ -22,7 +24,7 @@ It is an RDF document published by the Registry.
 	    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
 	    dcterms:licence <https://creativecommons.org/licenses/by/4.0/> ;
 	];
-	ib1:include-all-allow-additional ib1:permitGroup ;
+	ib1:includeAllAllowAditional ib1:permitGroup ;
 .
 ```
 
@@ -47,10 +49,10 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 (no modifier)
 : All the values in the requirements must be included for a term which does not have a modifier. No additonal values for that term are allowed.
 
-`ib1:include-all-allow-additional <term>`
+`ib1:includeAllAllowAdditional <term>`
 : All the values in the requirements must be included for this term, but additional values are allowed.
 
-`ib1:include-one-of <term>`
+`ib1:includeOneOf <term>`
 : Exactly one of the values in the requirements must be included for this term. No other values are allowed.
 
 

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -10,19 +10,19 @@ It is an RDF document published by the Registry.
 ```
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> . 
-@prefix ib1: <http://registry.ib1.org/ns/1.0/> .
+@prefix ib1: <http://registry.ib1.org/ns/1.0#> .
 
-<https://registry.ib1.org/class/supply-voltage>
-	a ib1:SchemeCatalogRequirements ;
+<https://registry.estf.ib1.org/scheme/electricity/standard/supply-voltage>
+		a ib1:SchemeCatalogRequirements ;
 	dcterms:title "Supply Voltage API Requirements" ;
 	ib1:requiredType dcat:DataService ;
 	ib1:requiredMetadata [ a ib1:RequiredMetadata ;
-	    dcat:endpointDescription <https://registry.ib1.org/api/electricity-voltage> ;
-	    ib1:heartbeatDescription <https://registry.ib1.org/api/heartbeat-simple> ;
+	    dcat:endpointDescription <https://registry.estf.ib1.org/scheme/electricity/api/voltage> ;
+	    ib1:heartbeatDescription <https://registry.estf.ib1.org/api/heartbeat-simple/1.0> ;
 	    ib1:sensitivityClass "IB1-SA" ;
-	    ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
-	    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
-	    dcterms:licence <https://creativecommons.org/licenses/by/4.0/> ;
+	    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/network-operator> ;
+	    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
+	    dcterms:licence <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 	];
 	ib1:includeAllAllowAditional ib1:permitGroup ;
 .
@@ -30,7 +30,7 @@ It is an RDF document published by the Registry.
 
 This example defines a standard Supply Voltage API that is provided by multiple providers in a Trust Framework. It specifies the API in detail with the `dcat:endpointDescription` referring to an OpenAPI specification hosted by the Registry. It uses a standard `ib1:heartbeatDescription` to check for liveness, using a standard heartbeat request defined in an OpenAPI specification hosted by the Registry.
 
-For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitGroup`. Because `ib1:include-all-allow-additional` is used for the access rules, it allows the publisher to widen access to additional groups, as long as the groups in this document are included.
+For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitGroup`. Because `ib1:includeAllAllowAditional` is used for the access rules, it allows the publisher to widen access to additional groups, as long as the groups in this document are included.
 
 ## Object specification
 

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -1,0 +1,60 @@
+
+# Scheme Catalog Requirements
+
+A Scheme Catalog Requirements Document specifies the metadata that a DCAT Catalog entry must contain for it to be Scheme-conforming. A conforming data source meets a common standard across a Scheme, where all Data Providers provide the same APIs, formats and meaning of data.
+
+It is an RDF document published by the Registry.
+
+## Example
+
+```
+@prefix ib1: <http://registry.ib1.org/ns/1.0/>
+
+<https://registry.ib1.org/class/supply-voltage>
+	a ib1:SchemeCatalogRequirements ;
+	dcterms:title "Supply Voltage API Requirements" ;
+	ib1:requiredType dcat:DataService ;
+	ib1:requiredMetadata [ a ib1:RequiredMetadata ;
+	    dcat:endpointDescription <https://registry.ib1.org/api/electricty-voltage> ;
+	    ib1:heartbeatDescription <https://registry.ib1.org/api/heartbeat-simple> ;
+	    ib1:sensitivityClass "IB1-SA" ;
+	    ib1:permitGroup <https://directory.ib1.org/group/network-operator> ;
+	    ib1:permitGroup <https://directory.ib1.org/group/report-provider> ;
+	    dcterms:licence <https://creativecommons.org/licenses/by/4.0/> ;
+	];
+	ib1:include-all-allow-additional ib1:permitGroup ;
+.
+```
+
+This example defines a standard Supply Voltage API that is provided by multiple providers in a Trust Framework. It specifies the API in detail with the `dcat:endpointDescription` referring to an OpenAPI specification hosted by the Registry. It uses a standard `ib1:heartbeatDescription` to check for liveness, using a standard heartbeat request defined in an OpenAPI specification hosted by the Registry.
+
+For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitGroup`. Because `ib1:include-all-allow-additional` is used for the access rules, it allows the publisher to widen access to additional groups, as long as the groups in this document are included.
+
+## Object specification
+
+An `ib1:SchemeCatalogRequirements` RDF object must contain these fields:
+
+`ib1:requiredType`
+: The type of the DCAT Catalog entry which describes this data source.
+
+`ib1:requiredMetadata`
+: A bnode which contains the metadata required to be Scheme-conforming. This bnode may contain any fields and metadata, and a conforming catalogue entry must contain it all, subject to the term modifiers.
+
+### Term modifiers
+
+The requirements for terms in the `ib1:requiredMetadata` are modified by terms in the top level object.
+
+(no modifier)
+: All the values in the requirements must be included for a term which does not have a modifier. No additonal values for that term are allowed.
+
+`ib1:include-all-allow-additional <term>`
+: All the values in the requirements must be included for this term, but additional values are allowed.
+
+`ib1:include-one-of <term>`
+: Exactly one of the values in the requirements must be included for this term. No other values are allowed.
+
+
+<!--stackedit_data:
+eyJoaXN0b3J5IjpbLTU5MTg4MjU2MiwxMzg5NzAyMDM4LDExMT
+MxMjg5NjksMTI2ODgzNjcwOF19
+-->

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -35,6 +35,14 @@ For access control, it specifies the `ib1:sensitivityClass`, and who can use the
 
 Because the API does not require end user consent, `ib1:requireAbsenceOf` is used to prohibit the use of an OAuth Issuer.
 
+## Versions
+
+The URL of a Scheme Catalog Requirements Document is a stable identifier that is used to find data sources in the Catalog by searching for all entries with this URL in the `dcterms:conformsTo` term.
+
+Scheme Catalog Requirements Documents are not versioned, and do not include version numbers in their URLs. Versioned URLs would prevent easy searching with SPARQL queries, and require a range of compatible versions to be included in the record.
+
+Scheme Catalog Requirements Documents may be updated with backwards compatible changes, for example, adding additional groups who are permitted to use the data source. Existing records are not updated automatically. A compliance process will detect out-of-date catalog entries, and notify providers to review the changes and update their record.
+
 ## Object specification
 
 An `ib1:SchemeCatalogRequirements` RDF object must contain these fields:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - 'Trust Framework Architecture': 'architecture.md'
   - 'Dataset Metadata': 'metadata.md'
   - 'Access Control and Capability Grant Language': 'access_control_specification.md'
+  - 'Scheme Catalog Requirements': 'scheme_catalog_requirements.md'
   - 'Glossary': 'glossary.md'
   - 'Additional Material': 'additional_material.md'
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
   - 'Scheme Catalog Requirements': 'scheme_catalog_requirements.md'
   - 'Glossary': 'glossary.md'
   - 'Additional Material': 'additional_material.md'
+  - 'Changelog': 'changelog.md'
 theme:
   name: material
   logo: assets/logo.png


### PR DESCRIPTION
Finally!

I renamed Permissions to Grant in metadata catalog to avoid a naming clash. I also considered "Permit" but felt it was too close, and I'd used ib1:permitGroup for access control.

There is still some tentative wording like "... are a plausible first cut but should not be considered definitive". I wonder whether words like this should be removed?

dcat:endpointDescription is a bit ugly with the "https://endpointurl-not-specified.ib1.org" thing, but it feels pragmatic to work with the OpenAPI spec and provide obvious errors when the consumer forgets to stick in the right URL variable.