### PR TITLE
Name things better & clarifications

### DIFF
--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -20,8 +20,8 @@ This specification will be iterated as use cases emerge. The current expectation
 <https://data.example.com/supply-voltage/v0>
     a dcat:DataService ;
 	# ...
-    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/report-provider> ;
-    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/archiver> ;
+    ib1:roleRequiredToAccess <https://directory.estf.ib1.org/scheme/electricity/role/report-provider> ;
+    ib1:roleRequiredToAccess <https://directory.estf.ib1.org/scheme/electricity/role/archiver> ;
     dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 .
 ```

--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -1,8 +1,8 @@
 # Access Control
 
-Access to data sources is controlled by group membership and licences.
+Access to data sources is controlled by roles and licences.
 
-A [catalog entry](metadata.md) specifies one or more groups and a licence. If a participant is a member of any of the groups, they may access the data source under the specified licence.
+A [catalog entry](metadata.md) specifies one or more roles and a licence. If a participant has any of the roles, they may access the data source under the specified licence.
 
 The Registry maintains a list of the permissions and obligations for access to a data source under a given licence.
 
@@ -20,13 +20,13 @@ This specification will be iterated as use cases emerge. The current expectation
 <https://data.example.com/supply-voltage/v0>
     a dcat:DataService ;
 	# ...
-    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
-    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/archiver> ;
+    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/report-provider> ;
+    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/archiver> ;
     dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 .
 ```
 
-These rules specify that members of either the "Report Provider" and "Archivers" groups may access the data with the Scheme's Voltage Reporting licence.
+These rules specify that members of either the "Report Provider" and "Archivers" roles may access the data with the Scheme's Voltage Reporting licence.
 
 
 ## Machine readable intepretation of Licences
@@ -48,12 +48,12 @@ For interoperability and consistency, Schemes should prefer to use Grants and Ob
 <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4>
 		a ib1:LicenceInterpretation ;
 	dcterms:license https://https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4/legal-text
-	ib1:grant ib1:use_any ;
-	ib1:grant ib1:adapt_any ;
-	ib1:grant ib1:combine_any ;
-	ib1:grant ib1:redistribute_original ;
-	ib1:grant ib1:combine_external ;
-	ib1:obligation ib1:by;
+	ib1:grant ib1:GrantUseAny ;
+	ib1:grant ib1:GrantAdaptAny ;
+	ib1:grant ib1:GrantCombineAny ;
+	ib1:grant ib1:GrantRedistributeCombined ;
+	ib1:grant ib1:GrantCombineExternal ;
+	ib1:obligation ib1:ObligationAttribution;
 .
 ```
 [dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/terms/license/)
@@ -76,47 +76,49 @@ Any additional grants designed **MUST** be within the namespace of the data prov
 
 **WARNING**: This section is provisional, the exact final set of base permissions has yet to be determined. Those shown below are a plausible first cut but should not be considered definitive.
 
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| Category                 | Grant name                                | Meaning                                                                                |
-+==========================+===========================================+========================================================================================+
-| **Use**                  |                                           | **Use the artefact internally**                                                        |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:use_any`                             | For any purpose                                                                        |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:use_dev`                             | For development purposes only (i.e. private or limited development of new              |
-|                          |                                           | works, products or services)                                                           |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:use_noncom`                          | For non-commercial purposes only (e.g. education, research, charity work               |
-|                          |                                           | etc.)                                                                                  |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| **Adapt**                |                                           | **Adapt the artefact for internal use**                                                |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:adapt_any`                           | For any purpose                                                                        |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:adapt_dev`                           | For development purposes only (i.e. private or limited development of new              |
-|                          |                                           | works, products or services)                                                           |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:adapt_noncom`                        | For non-commercial purposes only (e.g. education, research, charity work               |
-|                          |                                           | etc.)                                                                                  |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| **Combine**              |                                           | **Combine (‘remix’) the artefact**                                                     |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:combine_any`                         | With any other artefacts                                                               |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:combine_external`                    | With other external artefacts                                                          |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:combine_internal`                    | With the Data Consumer’s own products or services                                      |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| **Redistribute**         |                                           | **Redistribute (‘onward share’ - including to any customers of the Service Provider)** |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:redistribute_original`               | The original artefact                                                                  |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:redistribute_derived`                | Derivatives of the original artefact not produced from other data sets, i.e. filtered  |
-|                          |                                           | or cleaned data                                                                        |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-|                          | `ib1:redistribute_combined`               | Derivatives of the artefact produced through artefact combination or use in the Data   |
-|                          |                                           | Consumer’s own products or services                                                    |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
+**NOTE**: The URLs of the grants have been updated to meet the current naming conventions. The previous names are also shown in the table, and are automatically replaced by the Harvester.
+
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+| Category                 | Grant URL                       | Old URL                     | Meaning                                                                                |
++==========================+=================================+=============================+========================================================================================+
+| **Use**                  |                                 |                             | **Use the artefact internally**                                                        |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantUseAny`               | `ib1:use_any`               | For any purpose                                                                        |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantUseDevelopment`       | `ib1:use_dev`               | For development purposes only (i.e. private or limited development of new              |
+|                          |                                 |                             | works, products or services)                                                           |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantUseNonCommercial`     | `ib1:use_noncom`            | For non-commercial purposes only (e.g. education, research, charity work               |
+|                          |                                 |                             | etc.)                                                                                  |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+| **Adapt**                |                                 |                             | **Adapt the artefact for internal use**                                                |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantAdaptAny`             | `ib1:adapt_any`             | For any purpose                                                                        |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantAdaptDevelopment`     | `ib1:adapt_dev`             | For development purposes only (i.e. private or limited development of new              |
+|                          |                                 |                             | works, products or services)                                                           |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantAdaptNonCommercial`   | `ib1:adapt_noncom`          | For non-commercial purposes only (e.g. education, research, charity work               |
+|                          |                                 |                             | etc.)                                                                                  |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+| **Combine**              |                                 |                             | **Combine (‘remix’) the artefact**                                                     |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantCombineAny`           | `ib1:combine_any`           | With any other artefacts                                                               |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantCombineExternal`      | `ib1:combine_external`      | With other external artefacts                                                          |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantCombineInternal`      | `ib1:combine_internal`      | With the Data Consumer’s own products or services                                      |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+| **Redistribute**         |                                 |                             | **Redistribute (‘onward share’ - including to any customers of the Service Provider)** |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantRedistributeOriginal` | `ib1:redistribute_original` | The original artefact                                                                  |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantRedistributeDerived`  | `ib1:redistribute_derived`  | Derivatives of the original artefact not produced from other data sets, i.e. filtered  |
+|                          |                                 |                             | or cleaned data                                                                        |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
+|                          | `ib1:GrantRedistributeCombined` | `ib1:redistribute_combined` | Derivatives of the artefact produced through artefact combination or use in the Data   |
+|                          |                                 |                             | Consumer’s own products or services                                                    |
++--------------------------+---------------------------------+-----------------------------+----------------------------------------------------------------------------------------+
 
 ## Obligations
 
@@ -126,22 +128,26 @@ Obligations are constraints on what the data consumer can do with the data, rest
 
 **WARNING**: This set of standard obligations is provisional and may be subject to change
 
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| Obligation               | Name                                      | Explanation                                                                            |
-+==========================+===========================================+========================================================================================+
-| Fulltext                 | `ib1:ft`                                  | Re-users must display the full text of the license every time they use the work        |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| Attribution              | `ib1:by`                                  | Re-users must attribute the work to the original source when they use it               |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
-| ShareAlike               | `ib1:sa`                                  | Re-users who create derivatives of the work must release the derivatives under the     |
-|                          |                                           | same license as the original work, if they choose to distribute the derivatives        |
-+--------------------------+-------------------------------------------+----------------------------------------------------------------------------------------+
+**NOTE**: The URLs of the obligations have been updated to meet the current naming conventions. The previous names are also shown in the table, and are automatically replaced by the Harvester.
+
++--------------------------+------------------------------------+----------+------------------------------------------------------------------------------------+
+| Obligation               | URL                                | Old URL  | Explanation                                                                        |
++==========================+====================================+==========+====================================================================================+
+| Fulltext                 | `ib1:ObligationFullTextOfLicence`  | `ib1:ft` | Re-users must display the full text of the license every time they use the work    |
++--------------------------+------------------------------------+----------+------------------------------------------------------------------------------------+
+| Attribution              | `ib1:ObligationAttribution`        | `ib1:by` | Re-users must attribute the work to the original source when they use it           |
++--------------------------+------------------------------------+----------+------------------------------------------------------------------------------------+
+| ShareAlike               | `ib1:ObligationSameLicence`        | `ib1:sa` | Re-users who create derivatives of the work must release the derivatives under the |
+|                          |                                    |          | same license as the original work, if they choose to distribute the derivatives    |
++--------------------------+------------------------------------+----------+------------------------------------------------------------------------------------+
 
 **NOTE**: Two additional common constraints in existing (mostly open) licenses are NonCommercial and NoDerivatives. These are explicitly not included here as it is possible to express this through the access conditions (i.e. rather than declaring that a data set is only available for non-commercial usage it is better to say that only non-commercial entities may access it). This is not quite equivalent, but simpler and better defined than the relative minefield of defining ‘non commercial use’.
 <!--stackedit_data:
-eyJoaXN0b3J5IjpbLTEzMjMxMzY0NDIsNjExODUxNzY4LC04Mj
-k5NzM0MjcsMTkxMzMwNjE5MiwtMTE4ODE5OTQ5NSwtMjEzOTk0
-Nzg1MywyMDgwMjE4MzQsNzQwMTE3NDQ5LC0yMTMzOTc5NDYzLC
-03NDExMzYwOTAsOTM1MDgzNzQ3LC05NjkzMDEyNTAsMTE3NjE5
-MDkwMSwtMTk2OTEzODgyMl19
+eyJoaXN0b3J5IjpbMTk3OTg3MzM4MywtMTM4MTQzNjIzMiwtNj
+IwMTE2Nzc5LDQ1NDAzOTQ3MSwtMTk5OTg4MjkxMCwtMjQ4Mzkz
+MTU4LC0xMzIzMTM2NDQyLDYxMTg1MTc2OCwtODI5OTczNDI3LD
+E5MTMzMDYxOTIsLTExODgxOTk0OTUsLTIxMzk5NDc4NTMsMjA4
+MDIxODM0LDc0MDExNzQ0OSwtMjEzMzk3OTQ2MywtNzQxMTM2MD
+kwLDkzNTA4Mzc0NywtOTY5MzAxMjUwLDExNzYxOTA5MDEsLTE5
+NjkxMzg4MjJdfQ==
 -->

--- a/docs/access_control_specification.md
+++ b/docs/access_control_specification.md
@@ -142,12 +142,3 @@ Obligations are constraints on what the data consumer can do with the data, rest
 +--------------------------+------------------------------------+----------+------------------------------------------------------------------------------------+
 
 **NOTE**: Two additional common constraints in existing (mostly open) licenses are NonCommercial and NoDerivatives. These are explicitly not included here as it is possible to express this through the access conditions (i.e. rather than declaring that a data set is only available for non-commercial usage it is better to say that only non-commercial entities may access it). This is not quite equivalent, but simpler and better defined than the relative minefield of defining ‘non commercial use’.
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbMTk3OTg3MzM4MywtMTM4MTQzNjIzMiwtNj
-IwMTE2Nzc5LDQ1NDAzOTQ3MSwtMTk5OTg4MjkxMCwtMjQ4Mzkz
-MTU4LC0xMzIzMTM2NDQyLDYxMTg1MTc2OCwtODI5OTczNDI3LD
-E5MTMzMDYxOTIsLTExODgxOTk0OTUsLTIxMzk5NDc4NTMsMjA4
-MDIxODM0LDc0MDExNzQ0OSwtMjEzMzk3OTQ2MywtNzQxMTM2MD
-kwLDkzNTA4Mzc0NywtOTY5MzAxMjUwLDExNzYxOTA5MDEsLTE5
-NjkxMzg4MjJdfQ==
--->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,7 +21,4 @@
 	* added machine readable interpretation of licences.
 	* renamed "Permissions" to "Grants" to clarify intent and avoid a name clash with another concept.
 * [Scheme Catalog Requirements](scheme_catalog_requirements.md) are added to define how data sources comply with standards across the Scheme.
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbMzY1Mzc5Mjc5LDE3ODk1OTg1MTcsLTE4Nj
-AwNzUwODBdfQ==
--->
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@
 * Change values of `ib1:datasetAssurance` to URLs, with values using correct naming conventions.
 * Change URLs for Grants and Obligations to use correct naming conventions.
 * `dcterms:license` is the URL of a Licence Interpretation.
-* Add ib1:publisherRole to Scheme Catalog Requirements
+* Add `ib1:publisherRole` to Scheme Catalog Requirements
 
 ## Version 0.2beta, 22 June 2024
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@
 
 * Rename Group to Roles.
 * Change values of `ib1:sensitivityClass` to URLs, retaining the class names.
-* Change values of `ib1:datasetAssurance` to URls, with values using correct naming conventions.
+* Change values of `ib1:datasetAssurance` to URLs, with values using correct naming conventions.
 * Change URLs for Grants and Obligations to use correct naming conventions.
 * `dcterms:license` is the URL of a Licence Interpretation.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@
 * Change values of `ib1:datasetAssurance` to URLs, with values using correct naming conventions.
 * Change URLs for Grants and Obligations to use correct naming conventions.
 * `dcterms:license` is the URL of a Licence Interpretation.
-* Add `ib1:publisherRole` to Scheme Catalog Requirements
+* Add `ib1:roleRequiredToPublish` to Scheme Catalog Requirements
 
 ## Version 0.2beta, 22 June 2024
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 
 ## Version 0.3beta, 6 September 2024
 
-* Rename Group to Roles.
+* Rename Group to Roles, with `ib1:permitGroup` renamed to `ib1:roleRequiredToAccess`
 * Change values of `ib1:sensitivityClass` to URLs, retaining the class names.
 * Change values of `ib1:datasetAssurance` to URLs, with values using correct naming conventions.
 * Change URLs for Grants and Obligations to use correct naming conventions.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 * Change values of `ib1:datasetAssurance` to URLs, with values using correct naming conventions.
 * Change URLs for Grants and Obligations to use correct naming conventions.
 * `dcterms:license` is the URL of a Licence Interpretation.
+* Add ib1:publisherRole to Scheme Catalog Requirements
 
 ## Version 0.2beta, 22 June 2024
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,14 @@
 
 # Changelog
 
+## Version 0.3beta, 6 September 2024
+
+* Rename Group to Roles.
+* Change values of `ib1:sensitivityClass` to URLs, retaining the class names.
+* Change values of `ib1:datasetAssurance` to URls, with values using correct naming conventions.
+* Change URLs for Grants and Obligations to use correct naming conventions.
+* `dcterms:license` is the URL of a Licence Interpretation.
+
 ## Version 0.2beta, 22 June 2024
 
 * [Catalog Metadata](metadata.md) is now a DCAT Dataset or Data Service, extended with IB1 terms.
@@ -13,5 +21,6 @@
 	* renamed "Permissions" to "Grants" to clarify intent and avoid a name clash with another concept.
 * [Scheme Catalog Requirements](scheme_catalog_requirements.md) are added to define how data sources comply with standards across the Scheme.
 <!--stackedit_data:
-eyJoaXN0b3J5IjpbLTE4NjAwNzUwODBdfQ==
+eyJoaXN0b3J5IjpbMzY1Mzc5Mjc5LDE3ODk1OTg1MTcsLTE4Nj
+AwNzUwODBdfQ==
 -->

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 
 # Changelog
 
-## Version 0.3beta, 6 September 2024
+## Version 0.3beta, 10 September 2024
 
 * Rename Group to Roles, with `ib1:permitGroup` renamed to `ib1:roleRequiredToAccess`
 * Change values of `ib1:sensitivityClass` to URLs, retaining the class names.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -25,11 +25,13 @@ searching for particular kinds of data.
 ## Dataset or Data Service?
 
 A Dataset:
+
 * is provided as one or more downloadable files,
 * may be published as part of series of Datasets covering the same source of data over different time periods, and
 * should maintain historical access to previous periods.
 
 A Data Service:
+
 * is an API to query some data which uses parameters to specify a subset of data, including time period,
 * is specified formally by a machine readable API description, and
 * may require consent from a data subject external to the Trust Framework.
@@ -43,6 +45,7 @@ A Scheme-conforming Dataset or Data Service meets the data format and meaning re
 These requirements are published by the Scheme Registry as machine readable [Scheme Catalog Requirements Documents](scheme_catalog_requirements.md), and metadata files link to them to show their conformance.
 
 Most Datasets and Data Services are Scheme-conforming. A Data Provider may publish data which is not Scheme-conforming to:
+
 * use Scheme licences and roles to share ad-hoc Shared Data with Scheme participants (where the Scheme doesn't expressly disallow this), or
 * use the Catalog to include Open Data in a public index.
 
@@ -69,7 +72,7 @@ The following fields must be included in every DCAT object. Metadata will be vis
 : The URL of the Data Provider's record in the Scheme Directory.
 
 [dcterms:license](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#license)
-: The URL of a Licence. All use of this data source is subject to this Licence. Where a data source is Scheme-conforming, the URL will be registered in the Registry.
+: The URL of an `ib1:LicenceInterpretation`. All use of this data source is subject to this Licence. Where a data source is Scheme-conforming, the URL will be registered in the Registry.
 
 `ib1:trustFramework`
 : The URL of the Trust Framework(s) the dataset is assured under.
@@ -78,8 +81,9 @@ The following fields must be included in every DCAT object. Metadata will be vis
 : The assurance level for this dataset.
 
 `ib1:sensitivityClass`
-: The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this dataset. In the current IB1 Trust Framework this should always be one of [IB1-O](glossary.md#term-Data-sensitivity-class-open),  [IB1-SA](glossary.md#term-Data-sensitivity-class-shared-A) or [IB1-SB](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [IB1-O](glossary.md#term-Data-sensitivity-class-open) datasets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
-*Under development:* [IB1-SP](glossary.md#term-Data-sensitivity-class-personal) may be used for Data Service APIs which expose personal data with the end user's consent, in which case the `ib1:oauthIssuer` term must be present.
+: The [data sensitivity class](glossary.md#term-Data-sensitivity-class) of this dataset. In the current IB1 Trust Framework this should always be one of [`ib1:IB1-O`](glossary.md#term-Data-sensitivity-class-open),  [`ib1:IB1-SA`](glossary.md#term-Data-sensitivity-class-shared-A) or [`ib1:IB1-SB`](glossary.md#term-Data-sensitivity-class-shared-B), no other classes are permitted. The value of this property also determines the level of [API](glossary.md#term-Application-programming-interface) security imposed, with [`ib1:IB1-O`](glossary.md#term-Data-sensitivity-class-open) datasets being open data with no additional security, and the two shared data classes mandating [FAPI](glossary.md#term-Financial-Grade-API) security using the IB1 Trust Framework.
+*Under development:* [`ib1:IB1-SP`](glossary.md#term-Data-sensitivity-class-personal) may be used for Data Service APIs which expose personal data with the end user's consent, in which case the `ib1:oauthIssuer` term must be present.
+Previous versions of this standard used literal strings to identify the classes.
 
 More information about publishing assured data within a Trust Framework is available on the [How to become an assured data publisher](https://icebreakerone.org/sops/assured-data-publishing/) section of the Icebreaker One website.
 
@@ -91,8 +95,8 @@ Additional fields may be made mandatory for Scheme-conforming data sources by th
 `dcterms:conformsTo`
 : The URL of a Scheme Catalog Requirements Document in the Scheme Registry. Most metadata files will include this field.
 
-`ib1:permitGroup`
-: The URLs of one or more groups in the Directory which may access this data source subject to the Licence in the `dcterms:license` term, unless the data is open data with a `ib1:sensitivityClass` of `IB1-O`. See [Access Control Specification](access_control_specification.md).
+`ib1:permitRole`
+: The URLs of one or more roles in the Registry which may access this data source subject to the Licence in the `dcterms:license` term, unless the data is open data with a `ib1:sensitivityClass` of `ib1:IB1-O`. See [Access Control Specification](access_control_specification.md).
 
 ## Data Service metadata fields
 
@@ -105,7 +109,7 @@ Data Services are represented by `dcat:DataService` objects with the common mand
 : The URL of this specific instance of the API. It is interpolated into the `url` specified in the OpenAPI file using the `endpointURL` variable.
 
 `ib1:oauthIssuer`
-: Where access to data requires end user consent or selection of an account at the provider, the URL of the [OAuth Issuer](https://datatracker.ietf.org/doc/html/rfc8414#section-2) which is used to authenticate before accessing this Data Service. This field is required for data with a `ib1:sensitivityClass` of `IP1-SP`, and may be used for other classes.
+: Where access to data requires end user consent or selection of an account at the provider, the URL of the [OAuth Issuer](https://datatracker.ietf.org/doc/html/rfc8414#section-2) which is used to authenticate before accessing this Data Service. This field is required for data with a `ib1:sensitivityClass` of `ib1:IP1-SP`, and may be used for other classes.
 
 `ib1:heartbeatDescription`
 : An optional URL of an OpenAPI file (with Server specified as `dcat:endpointDescription`), which contains a single Path with a 200 response defined. This term will typically be the URL of one of a small number of standard OpenAPI files published in the Registry.
@@ -191,10 +195,11 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
     ib1:heartbeatDescription <https://registry.estf.ib1.org/api/heartbeat-simple/1.0> ;
     dcat:endpointURL <https://grid03.api.example.com/generation-voltage/v0> ;
     ib1:trustFramework <http://registry.estf.ib1.org/trust-framework> ;
-    ib1:datasetAssurance "IcebreakerOne.DatasetLevel1" ;
-    ib1:sensitivityClass "IB1-SA" ;
-    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/network-operator> ;
-    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
+    ib1:scheme <http://registry.estf.ib1.org/scheme/electricty> ;
+    ib1:datasetAssurance ib1:AssuranceLevel1 ;
+    ib1:sensitivityClass ib1:IB1-SA ;
+    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/network-operator> ;
+    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/report-provider> ;
     dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 .
 ```
@@ -219,10 +224,11 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
 	    "electricity"@en,
 	    "retrofit"@en ;
     ib1:trustFramework <http://registry.estf.ib1.org/trust-framework> ;
-    ib1:datasetAssurance "IcebreakerOne.DatasetLevel1" ;
-    ib1:sensitivityClass "IB1-SA" ;
-    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/network-operator> ;
-    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
+    ib1:scheme <http://registry.estf.ib1.org/scheme/electricty> ;
+    ib1:datasetAssurance ib1:AssuranceLevel1 ;
+    ib1:sensitivityClass ib1:IB1-SA ;
+    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/network-operator> ;
+    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/report-provider> ;
     dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/generation-reporting/2.1> ;
 .
 
@@ -240,11 +246,11 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
 .
 ```
 <!--stackedit_data:
-eyJoaXN0b3J5IjpbLTE4MzY0ODI1OTIsLTExODU4MjA4MjMsMz
-UyNDI5NSwtMTc3Mjk1NTY3OSwtMTUwMzY5NDAwLDU0MDU3NjUz
-LC0xMDMyMjMyNTIzLC04NDA2NTUxODksLTU3OTM2NTg2MCwtMT
-M2MzYzMTQwMSwtMTQ3MDQzMzM2MywxNzUxMjM0OTkwLC02MTE3
-OTM1MTAsMTUxNzk1OTM4OCwxMTg5MzQyMzY2LDM1MTI3Njc4MC
-w1OTQ5MjE2NjUsMTE0OTc3MTc0MCwtMjU0Mjk4NzQ4LDIxMjk2
-NzMzNzNdfQ==
+eyJoaXN0b3J5IjpbMTQyMzkyMzUwLDE3OTc0NjIyNzgsLTkyOT
+Q1OTg4MiwxOTA5NjA2MzIsLTE4MzY0ODI1OTIsLTExODU4MjA4
+MjMsMzUyNDI5NSwtMTc3Mjk1NTY3OSwtMTUwMzY5NDAwLDU0MD
+U3NjUzLC0xMDMyMjMyNTIzLC04NDA2NTUxODksLTU3OTM2NTg2
+MCwtMTM2MzYzMTQwMSwtMTQ3MDQzMzM2MywxNzUxMjM0OTkwLC
+02MTE3OTM1MTAsMTUxNzk1OTM4OCwxMTg5MzQyMzY2LDM1MTI3
+Njc4MF19
 -->

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -109,7 +109,7 @@ Data Services are represented by `dcat:DataService` objects with the common mand
 : The URL of this specific instance of the API. It is interpolated into the `url` specified in the OpenAPI file using the `endpointURL` variable.
 
 `ib1:oauthIssuer`
-: Where access to data requires end user consent or selection of an account at the provider, the URL of the [OAuth Issuer](https://datatracker.ietf.org/doc/html/rfc8414#section-2) which is used to authenticate before accessing this Data Service. This field is required for data with a `ib1:sensitivityClass` of `ib1:IP1-SP`, and may be used for other classes.
+: Where access to data requires end user consent or selection of an account at the provider, the URL of the [OAuth Issuer](https://datatracker.ietf.org/doc/html/rfc8414#section-2) which is used to authenticate before accessing this Data Service. This field is required for data with a `ib1:sensitivityClass` of `ib1:IB1-SP`, and may be used for other classes.
 
 `ib1:heartbeatDescription`
 : An optional URL of an OpenAPI file (with Server specified as `dcat:endpointDescription`), which contains a single Path with a 200 response defined. This term will typically be the URL of one of a small number of standard OpenAPI files published in the Registry.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -95,7 +95,7 @@ Additional fields may be made mandatory for Scheme-conforming data sources by th
 `dcterms:conformsTo`
 : The URL of a Scheme Catalog Requirements Document in the Scheme Registry. Most metadata files will include this field.
 
-`ib1:permitRole`
+`ib1:roleRequiredToAccess`
 : The URLs of one or more roles in the Registry which may access this data source subject to the Licence in the `dcterms:license` term, unless the data is open data with a `ib1:sensitivityClass` of `ib1:IB1-O`. See [Access Control Specification](access_control_specification.md).
 
 ## Data Service metadata fields
@@ -198,8 +198,8 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
     ib1:scheme <http://registry.estf.ib1.org/scheme/electricty> ;
     ib1:datasetAssurance ib1:AssuranceLevel1 ;
     ib1:sensitivityClass ib1:IB1-SA ;
-    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/network-operator> ;
-    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/report-provider> ;
+    ib1:roleRequiredToAccess <https://registry.estf.ib1.org/scheme/electricity/role/network-operator> ;
+    ib1:roleRequiredToAccess <https://registry.estf.ib1.org/scheme/electricity/role/report-provider> ;
     dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 .
 ```
@@ -227,8 +227,8 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
     ib1:scheme <http://registry.estf.ib1.org/scheme/electricty> ;
     ib1:datasetAssurance ib1:AssuranceLevel1 ;
     ib1:sensitivityClass ib1:IB1-SA ;
-    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/network-operator> ;
-    ib1:permitRole <https://registry.estf.ib1.org/scheme/electricity/role/report-provider> ;
+    ib1:roleRequiredToAccess <https://registry.estf.ib1.org/scheme/electricity/role/network-operator> ;
+    ib1:roleRequiredToAccess <https://registry.estf.ib1.org/scheme/electricity/role/report-provider> ;
     dcterms:license <https://registry.estf.ib1.org/scheme/electricity/licence/generation-reporting/2.1> ;
 .
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -245,12 +245,3 @@ We encourage use of the `dcat:keyword` list for datasets. These translate to “
     dcterms:title "Generation Reports from My Energy Company"@en ;
 .
 ```
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbMTQyMzkyMzUwLDE3OTc0NjIyNzgsLTkyOT
-Q1OTg4MiwxOTA5NjA2MzIsLTE4MzY0ODI1OTIsLTExODU4MjA4
-MjMsMzUyNDI5NSwtMTc3Mjk1NTY3OSwtMTUwMzY5NDAwLDU0MD
-U3NjUzLC0xMDMyMjMyNTIzLC04NDA2NTUxODksLTU3OTM2NTg2
-MCwtMTM2MzYzMTQwMSwtMTQ3MDQzMzM2MywxNzUxMjM0OTkwLC
-02MTE3OTM1MTAsMTUxNzk1OTM4OCwxMTg5MzQyMzY2LDM1MTI3
-Njc4MF19
--->

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -76,9 +76,3 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 `ib1:requireAbsenceOf <term>`
 : The term must not be present.
 
-
-<!--stackedit_data:
-eyJoaXN0b3J5IjpbLTE0NzgyNDIwODUsLTEwODkwNjYwNDUsLT
-I0NzYwNzksLTU5MTg4MjU2MiwxMzg5NzAyMDM4LDExMTMxMjg5
-NjksMTI2ODgzNjcwOF19
--->

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -19,19 +19,19 @@ It is an RDF document published by the Registry.
 	ib1:requiredMetadata [ a ib1:RequiredMetadata ;
 	    dcat:endpointDescription <https://registry.estf.ib1.org/scheme/electricity/api/voltage> ;
 	    ib1:heartbeatDescription <https://registry.estf.ib1.org/api/heartbeat-simple/1.0> ;
-	    ib1:sensitivityClass "IB1-SA" ;
-	    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/network-operator> ;
-	    ib1:permitGroup <https://directory.estf.ib1.org/scheme/electricity/group/report-provider> ;
+	    ib1:sensitivityClass ib1:IB1-SA ;
+	    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/network-operator> ;
+	    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/report-provider> ;
 	    dcterms:licence <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 	];
-	ib1:requireAllAndAllowAdditional ib1:permitGroup ;
+	ib1:requireAllAndAllowAdditional ib1:permitRole ;
 	ib1:requireAbsenceOf ib1:oauthIssuer ;
 .
 ```
 
 This example defines a standard Supply Voltage API that is provided by multiple providers in a Trust Framework. It specifies the API in detail with the `dcat:endpointDescription` referring to an OpenAPI specification hosted by the Registry. It uses a standard `ib1:heartbeatDescription` to check for liveness, using a standard heartbeat request defined in an OpenAPI specification hosted by the Registry.
 
-For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitGroup`. Because `ib1:requireAllAndAllowAdditional` is used for the access rules, it allows the publisher to widen access to additional groups, as long as the groups in this document are included.
+For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitRole`. Because `ib1:requireAllAndAllowAdditional` is used for the access rules, it allows the publisher to widen access to additional roles, as long as the roles in this document are included.
 
 Because the API does not require end user consent, `ib1:requireAbsenceOf` is used to prohibit the use of an OAuth Issuer.
 
@@ -41,7 +41,7 @@ The URL of a Scheme Catalog Requirements Document is a stable identifier that is
 
 Scheme Catalog Requirements Documents are not versioned, and do not include version numbers in their URLs. Versioned URLs would prevent easy searching with SPARQL queries, and require a range of compatible versions to be included in the record.
 
-Scheme Catalog Requirements Documents may be updated with backwards compatible changes, for example, adding additional groups who are permitted to use the data source. Existing records are not updated automatically. A compliance process will detect out-of-date catalog entries, and notify providers to review the changes and update their record.
+Scheme Catalog Requirements Documents may be updated with backwards compatible changes, for example, adding additional roles who are permitted to use the data source. Existing records are not updated automatically. A compliance process will detect out-of-date catalog entries, and notify providers to review the changes and update their record.
 
 ## Object specification
 
@@ -74,6 +74,7 @@ The requirements for terms in the `ib1:requiredMetadata` are modified by terms i
 
 
 <!--stackedit_data:
-eyJoaXN0b3J5IjpbLTU5MTg4MjU2MiwxMzg5NzAyMDM4LDExMT
-MxMjg5NjksMTI2ODgzNjcwOF19
+eyJoaXN0b3J5IjpbLTE0NzgyNDIwODUsLTEwODkwNjYwNDUsLT
+I0NzYwNzksLTU5MTg4MjU2MiwxMzg5NzAyMDM4LDExMTMxMjg5
+NjksMTI2ODgzNjcwOF19
 -->

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -21,18 +21,18 @@ It is an RDF document published in the Registry.
 	    dcat:endpointDescription <https://registry.estf.ib1.org/scheme/electricity/api/voltage> ;
 	    ib1:heartbeatDescription <https://registry.estf.ib1.org/api/heartbeat-simple/1.0> ;
 	    ib1:sensitivityClass ib1:IB1-SA ;
-	    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/network-operator> ;
-	    ib1:permitRole <https://directory.estf.ib1.org/scheme/electricity/role/report-provider> ;
+	    ib1:roleRequiredToAccess <https://directory.estf.ib1.org/scheme/electricity/role/network-operator> ;
+	    ib1:roleRequiredToAccess <https://directory.estf.ib1.org/scheme/electricity/role/report-provider> ;
 	    dcterms:licence <https://registry.estf.ib1.org/scheme/electricity/licence/voltage-reporting/1.4> ;
 	];
-	ib1:requireAllAndAllowAdditional ib1:permitRole ;
+	ib1:requireAllAndAllowAdditional ib1:roleRequiredToAccess ;
 	ib1:requireAbsenceOf ib1:oauthIssuer ;
 .
 ```
 
 This example defines a standard Supply Voltage API that is provided by multiple providers in a Trust Framework. It specifies the API in detail with the `dcat:endpointDescription` referring to an OpenAPI specification hosted by the Registry. It uses a standard `ib1:heartbeatDescription` to check for liveness, using a standard heartbeat request defined in an OpenAPI specification hosted by the Registry.
 
-For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:permitRole`. Because `ib1:requireAllAndAllowAdditional` is used for the access rules, it allows the publisher to widen access to additional roles, as long as the roles in this document are included.
+For access control, it specifies the `ib1:sensitivityClass`, and who can use the API with `ib1:roleRequiredToAccess`. Because `ib1:requireAllAndAllowAdditional` is used for the access rules, it allows the publisher to widen access to additional roles, as long as the roles in this document are included.
 
 Because the API does not require end user consent, `ib1:requireAbsenceOf` is used to prohibit the use of an OAuth Issuer.
 

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -1,9 +1,9 @@
 
 # Scheme Catalog Requirements
 
-A Scheme-conforming data source meets a common standard across a Scheme, where all Data Providers provide the same APIs, formats and meaning of data. A Scheme Catalog Requirements Document specifies the metadata that a DCAT Catalog entry must contain for it to be Scheme-conforming, and which roles may publish a conforming data source. 
+A Scheme-conforming data source meets a common standard across a Scheme. These standards are followed by the Data Providers so that the same kind of data is published across the Scheme using the same APIs, formats and meaning of data. A Scheme Catalog Requirements Document specifies the metadata that a DCAT Catalog entry must contain for it to be Scheme-conforming, and which roles may publish a conforming data source. 
 
-It is an RDF document published in the Registry.
+It is an RDF document published in the Registry, and the metadata links to machine readable Licence, API and format specifications which are also published in the Registry.
 
 ## Example
 

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -16,7 +16,7 @@ It is an RDF document published in the Registry.
 		a ib1:SchemeCatalogRequirements ;
 	dcterms:title "Supply Voltage API Requirements" ;
 	ib1:requiredType dcat:DataService ;
-	ib1:publisherRole <https://directory.estf.ib1.org/scheme/electricity/role/generator> ;
+	ib1:roleRequiredToPublish <https://directory.estf.ib1.org/scheme/electricity/role/generator> ;
 	ib1:requiredMetadata [ a ib1:RequiredMetadata ;
 	    dcat:endpointDescription <https://registry.estf.ib1.org/scheme/electricity/api/voltage> ;
 	    ib1:heartbeatDescription <https://registry.estf.ib1.org/api/heartbeat-simple/1.0> ;
@@ -54,8 +54,8 @@ An `ib1:SchemeCatalogRequirements` RDF object must contain these fields:
 `ib1:requiredMetadata`
 : A bnode which contains the metadata required to be Scheme-conforming. This bnode may contain any fields and metadata, and a conforming catalogue entry must contain it all, subject to the term modifiers.
 
-`ib1:publisherRole`
-: The URL of the Role which is permitted to publish a Catalog entry conforming to this standard. If muliple Roles are specified, any of those Roles may publish a catalog entry.
+`ib1:roleRequiredToPublish`
+: The URL of the Role which is permitted to publish a Catalog entry conforming to this standard. If multiple Roles are specified, any of those Roles may publish a catalog entry.
 
 ### Term modifiers
 

--- a/docs/scheme_catalog_requirements.md
+++ b/docs/scheme_catalog_requirements.md
@@ -1,9 +1,9 @@
 
 # Scheme Catalog Requirements
 
-A Scheme Catalog Requirements Document specifies the metadata that a DCAT Catalog entry must contain for it to be Scheme-conforming. A conforming data source meets a common standard across a Scheme, where all Data Providers provide the same APIs, formats and meaning of data.
+A Scheme-conforming data source meets a common standard across a Scheme, where all Data Providers provide the same APIs, formats and meaning of data. A Scheme Catalog Requirements Document specifies the metadata that a DCAT Catalog entry must contain for it to be Scheme-conforming, and which roles may publish a conforming data source. 
 
-It is an RDF document published by the Registry.
+It is an RDF document published in the Registry.
 
 ## Example
 
@@ -16,6 +16,7 @@ It is an RDF document published by the Registry.
 		a ib1:SchemeCatalogRequirements ;
 	dcterms:title "Supply Voltage API Requirements" ;
 	ib1:requiredType dcat:DataService ;
+	ib1:publisherRole <https://directory.estf.ib1.org/scheme/electricity/role/generator> ;
 	ib1:requiredMetadata [ a ib1:RequiredMetadata ;
 	    dcat:endpointDescription <https://registry.estf.ib1.org/scheme/electricity/api/voltage> ;
 	    ib1:heartbeatDescription <https://registry.estf.ib1.org/api/heartbeat-simple/1.0> ;
@@ -52,6 +53,9 @@ An `ib1:SchemeCatalogRequirements` RDF object must contain these fields:
 
 `ib1:requiredMetadata`
 : A bnode which contains the metadata required to be Scheme-conforming. This bnode may contain any fields and metadata, and a conforming catalogue entry must contain it all, subject to the term modifiers.
+
+`ib1:publisherRole`
+: The URL of the Role which is permitted to publish a Catalog entry conforming to this standard. If muliple Roles are specified, any of those Roles may publish a catalog entry.
 
 ### Term modifiers
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ markdown_extensions:
   - markdown_grid_tables
   - tables
   - attr_list
+  - def_list
 plugins:
   - social:
       cards_layout_options:


### PR DESCRIPTION
* Rename Group to Roles.
* Change values of `ib1:sensitivityClass` to URLs, retaining the class names.
* Change values of `ib1:datasetAssurance` to URls, with values using correct naming conventions.
* Change URLs for Grants and Obligations to use correct naming conventions.
* `dcterms:license` is the URL of a Licence Interpretation.

Also has the formatting fixes in #2, because of StackEdit. Those fixes should go in first to fix the formatting of the current version.

Propose this should be 0.3beta.